### PR TITLE
[codex] Make executor policy enforce fail-closed by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,11 @@ N8N_HOST=n8n.example.com
 
 # Policy Engine (OPA)
 OPA_URL=http://opa:8181
-POLICY_MODE=shadow
+POLICY_MODE=enforce
 POLICY_TIMEOUT_MS=800
-POLICY_FAIL_MODE=open
+POLICY_FAIL_MODE=closed
+# Development-only override for advisory/fail-open testing. Leave unset in normal deployments.
+# POLICY_ALLOW_UNSAFE=true
 OPA_BUNDLE_URL=http://policy-bundle-server:8088/bundles/policy.tar.gz
 OPA_POLL_INTERVAL=10
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ At minimum configure these in `.env`:
 
 Reference: `.env.example`
 
+Policy enforcement defaults to `POLICY_MODE=enforce` and `POLICY_FAIL_MODE=closed`. Development-only advisory or fail-open overrides require explicit `POLICY_ALLOW_UNSAFE=true`.
+
 ## Common Commands
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -313,15 +313,18 @@ Set policy controls with environment variables:
 
 ```bash
 export OPA_URL="http://opa:8181"
-export POLICY_MODE="enforce"     # shadow or enforce
+export POLICY_MODE="enforce"
 export POLICY_TIMEOUT_MS="800"
-export POLICY_FAIL_MODE="closed" # open or closed
+export POLICY_FAIL_MODE="closed"
+# Development-only override for unsafe advisory/fail-open testing
+# export POLICY_ALLOW_UNSAFE="true"
 ```
 
-- `shadow`: evaluate + log decisions only
+- Default posture: `POLICY_MODE=enforce` and `POLICY_FAIL_MODE=closed`
+- `shadow`: evaluate + log decisions only. Requires `POLICY_ALLOW_UNSAFE=true`.
 - `enforce`: block `deny` and `requires_approval`
 - `closed`: deny requests if OPA is unavailable
-- `open`: allow requests if OPA is unavailable (temporary rollout mode)
+- `open`: allow requests if OPA is unavailable. Requires `POLICY_ALLOW_UNSAFE=true` and should be limited to development-only override cases.
 
 ### 5. Monitor Resource Usage
 

--- a/docs/policy-input-output-contract.md
+++ b/docs/policy-input-output-contract.md
@@ -141,6 +141,10 @@ Callers of `PolicyClient.evaluate()` should consume this normalized shape.
 
 ## Failure/Fallback Semantics
 
+Default executor posture is `POLICY_MODE=enforce` with `POLICY_FAIL_MODE=closed`.
+
+Unsafe advisory or fail-open operation is blocked at startup unless an operator explicitly sets `POLICY_ALLOW_UNSAFE=true` for development-only override scenarios.
+
 When OPA is unavailable, `executor/policy_client.py` returns fallback results in the same normalized shape above (no outer `result` key), based on `POLICY_FAIL_MODE`:
 
 - `open`: `decision=allow`, `allow=true`, `requires_approval=false`

--- a/executor/policy_client.py
+++ b/executor/policy_client.py
@@ -3,10 +3,14 @@ Policy client for OPA-based authorization and risk checks.
 """
 
 import json
+import logging
 import os
 import urllib.error
 import urllib.request
 from typing import Any, Dict
+
+
+logger = logging.getLogger(__name__)
 
 
 class PolicyClient:
@@ -14,10 +18,53 @@ class PolicyClient:
 
     def __init__(self):
         self.opa_url = os.environ.get("OPA_URL", "http://opa:8181").rstrip("/")
-        self.mode = os.environ.get("POLICY_MODE", "shadow").lower()
-        self.fail_mode = os.environ.get("POLICY_FAIL_MODE", "open").lower()
+        self.mode = os.environ.get("POLICY_MODE", "enforce").lower()
+        self.fail_mode = os.environ.get("POLICY_FAIL_MODE", "closed").lower()
         self.timeout_ms = int(os.environ.get("POLICY_TIMEOUT_MS", "800"))
+        self.allow_unsafe = os.environ.get("POLICY_ALLOW_UNSAFE", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
         self.endpoint = f"{self.opa_url}/v1/data/ai/policy/result"
+        self._validate_configuration()
+
+    def _validate_configuration(self) -> None:
+        valid_modes = {"shadow", "enforce"}
+        if self.mode not in valid_modes:
+            raise ValueError(
+                f"Invalid POLICY_MODE={self.mode!r}; expected one of {sorted(valid_modes)}"
+            )
+
+        valid_fail_modes = {"open", "closed"}
+        if self.fail_mode not in valid_fail_modes:
+            raise ValueError(
+                f"Invalid POLICY_FAIL_MODE={self.fail_mode!r}; expected one of {sorted(valid_fail_modes)}"
+            )
+
+        unsafe_reasons = []
+        if self.mode != "enforce":
+            unsafe_reasons.append(f"POLICY_MODE={self.mode}")
+        if self.fail_mode != "closed":
+            unsafe_reasons.append(f"POLICY_FAIL_MODE={self.fail_mode}")
+
+        if not unsafe_reasons:
+            return
+
+        if not self.allow_unsafe:
+            joined_reasons = ", ".join(unsafe_reasons)
+            raise ValueError(
+                "Unsafe policy configuration requires explicit operator intent: "
+                f"{joined_reasons}. Set POLICY_ALLOW_UNSAFE=true only for development overrides."
+            )
+
+        logger.warning(
+            "Unsafe policy override enabled: mode=%s fail_mode=%s allow_unsafe=%s",
+            self.mode,
+            self.fail_mode,
+            self.allow_unsafe,
+        )
 
     def evaluate(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Evaluate a policy input and normalize response fields."""

--- a/executor/requirements.txt
+++ b/executor/requirements.txt
@@ -13,7 +13,6 @@ pytest-timeout==2.2.0
 # Type hints
 typing-extensions==4.9.0
 
-# Linting and formatting (development)
-black==24.3.0
+# Static analysis helpers (development)
 flake8==7.0.0
 mypy==1.8.0

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -471,9 +471,9 @@ def test_policy_metrics_exposed_for_decisions_errors_and_latency():
             "error": None,
         },
         {
-            "decision": "allow",
-            "allow": True,
-            "requires_approval": False,
+            "decision": "deny",
+            "allow": False,
+            "requires_approval": True,
             "risk_score": 0,
             "reasons": ["policy_unavailable"],
             "error": "opa timeout",
@@ -540,37 +540,37 @@ def test_policy_metrics_exposed_for_decisions_errors_and_latency():
     assert allow_payload["status"] == "success"
     assert deny_status == 403
     assert deny_payload["status"] == "error"
-    assert fallback_status == 200
-    assert fallback_payload["status"] == "success"
+    assert fallback_status == 403
+    assert fallback_payload["status"] == "error"
     assert fallback_payload["policy"]["error"] == "opa timeout"
 
     assert metrics_status == 200
     policy_metrics = metrics_payload["metrics"]["policy"]
     request_metrics = metrics_payload["metrics"]["requests"]
     assert policy_metrics["total"] == 3
-    assert policy_metrics["allow"] == 2
-    assert policy_metrics["deny"] == 1
+    assert policy_metrics["allow"] == 1
+    assert policy_metrics["deny"] == 2
     assert policy_metrics["requires_approval"] == 0
     assert policy_metrics["errors"] == 1
     assert policy_metrics["latency_ms_count"] == 3
     assert round(policy_metrics["latency_ms_sum"], 3) == 60.0
     assert request_metrics["total"] == 3
-    assert request_metrics["errors"] == 1
+    assert request_metrics["errors"] == 2
     assert request_metrics["methods"]["POST"] == 3
-    assert request_metrics["statuses"]["200"] == 2
-    assert request_metrics["statuses"]["403"] == 1
+    assert request_metrics["statuses"]["200"] == 1
+    assert request_metrics["statuses"]["403"] == 2
 
     assert prom_status == 200
     assert "executor_policy_eval_total 3" in prom_body
-    assert 'executor_policy_decisions_total{decision="allow"} 2' in prom_body
-    assert 'executor_policy_decisions_total{decision="deny"} 1' in prom_body
+    assert 'executor_policy_decisions_total{decision="allow"} 1' in prom_body
+    assert 'executor_policy_decisions_total{decision="deny"} 2' in prom_body
     assert "executor_policy_eval_errors_total 1" in prom_body
     assert "executor_policy_eval_latency_ms_sum 60.000" in prom_body
     assert "executor_policy_eval_latency_ms_count 3" in prom_body
     assert "executor_policy_eval_latency_ms_avg 20.000" in prom_body
     assert "executor_policy_eval_latency_ms_avg " in prom_body
     assert "executor_http_requests_total 3" in prom_body
-    assert "executor_http_request_errors_total 1" in prom_body
+    assert "executor_http_request_errors_total 2" in prom_body
     assert 'executor_http_requests_by_method_total{method="POST"} 3' in prom_body
-    assert 'executor_http_requests_by_status_total{status="200"} 2' in prom_body
-    assert 'executor_http_requests_by_status_total{status="403"} 1' in prom_body
+    assert 'executor_http_requests_by_status_total{status="200"} 1' in prom_body
+    assert 'executor_http_requests_by_status_total{status="403"} 2' in prom_body

--- a/executor/test_policy_client.py
+++ b/executor/test_policy_client.py
@@ -6,6 +6,7 @@ from executor.policy_client import PolicyClient
 def test_policy_client_defaults_to_enforce_and_fail_closed(monkeypatch):
     monkeypatch.delenv("POLICY_MODE", raising=False)
     monkeypatch.delenv("POLICY_FAIL_MODE", raising=False)
+    monkeypatch.delenv("POLICY_ALLOW_UNSAFE", raising=False)
 
     client = PolicyClient()
 
@@ -14,7 +15,9 @@ def test_policy_client_defaults_to_enforce_and_fail_closed(monkeypatch):
 
 
 def test_policy_client_fallback_denies_when_opa_unavailable(monkeypatch):
+    monkeypatch.delenv("POLICY_MODE", raising=False)
     monkeypatch.delenv("POLICY_FAIL_MODE", raising=False)
+    monkeypatch.delenv("POLICY_ALLOW_UNSAFE", raising=False)
 
     client = PolicyClient()
     result = client._fallback_result("opa unavailable")

--- a/executor/test_policy_client.py
+++ b/executor/test_policy_client.py
@@ -1,0 +1,48 @@
+import pytest
+
+from executor.policy_client import PolicyClient
+
+
+def test_policy_client_defaults_to_enforce_and_fail_closed(monkeypatch):
+    monkeypatch.delenv("POLICY_MODE", raising=False)
+    monkeypatch.delenv("POLICY_FAIL_MODE", raising=False)
+
+    client = PolicyClient()
+
+    assert client.mode == "enforce"
+    assert client.fail_mode == "closed"
+
+
+def test_policy_client_fallback_denies_when_opa_unavailable(monkeypatch):
+    monkeypatch.delenv("POLICY_FAIL_MODE", raising=False)
+
+    client = PolicyClient()
+    result = client._fallback_result("opa unavailable")
+
+    assert result["decision"] == "deny"
+    assert result["allow"] is False
+    assert result["requires_approval"] is True
+    assert result["reasons"] == ["policy_unavailable"]
+    assert result["error"] == "opa unavailable"
+
+
+def test_policy_client_rejects_unsafe_configuration_without_override(monkeypatch):
+    monkeypatch.setenv("POLICY_MODE", "shadow")
+    monkeypatch.setenv("POLICY_FAIL_MODE", "open")
+    monkeypatch.delenv("POLICY_ALLOW_UNSAFE", raising=False)
+
+    with pytest.raises(ValueError, match="Unsafe policy configuration requires explicit operator intent"):
+        PolicyClient()
+
+
+def test_policy_client_allows_unsafe_configuration_with_explicit_override(monkeypatch, caplog):
+    monkeypatch.setenv("POLICY_MODE", "shadow")
+    monkeypatch.setenv("POLICY_FAIL_MODE", "open")
+    monkeypatch.setenv("POLICY_ALLOW_UNSAFE", "true")
+
+    with caplog.at_level("WARNING"):
+        client = PolicyClient()
+
+    assert client.mode == "shadow"
+    assert client.fail_mode == "open"
+    assert "Unsafe policy override enabled" in caplog.text

--- a/policy/opa/README.md
+++ b/policy/opa/README.md
@@ -50,9 +50,11 @@ Inner policy result object shape (this is the value under OPA HTTP `result`):
 
 ## Modes
 
-- `POLICY_MODE=shadow`: evaluate and log only
+- Default posture: `POLICY_MODE=enforce` and `POLICY_FAIL_MODE=closed`
+- `POLICY_MODE=shadow`: evaluate and log only. Requires `POLICY_ALLOW_UNSAFE=true`.
 - `POLICY_MODE=enforce`: block `deny` and `requires_approval`
-- `POLICY_FAIL_MODE=open|closed`: behavior on OPA outage
+- `POLICY_FAIL_MODE=closed`: deny requests if OPA is unavailable
+- `POLICY_FAIL_MODE=open`: allow requests if OPA is unavailable. Requires `POLICY_ALLOW_UNSAFE=true`.
 
 ## Local policy tests
 

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 docker run --rm -v "$PWD:/work" -w /work python:3.11-slim bash -lc "\
   pip install --no-cache-dir -r executor/requirements.txt && \
-  pytest -q executor/test_sandbox.py executor/test_api_server_execute.py executor/test_api_server_session_lifecycle.py executor/test_templates.py"
+  pytest -q executor/test_sandbox.py executor/test_api_server_execute.py executor/test_api_server_session_lifecycle.py executor/test_policy_client.py executor/test_templates.py"


### PR DESCRIPTION
## Summary
- make executor policy enforcement authoritative by default with `POLICY_MODE=enforce`
- switch policy backend fallback to fail closed and require an explicit `POLICY_ALLOW_UNSAFE=true` override for advisory/fail-open development modes
- document the safe-by-default posture and add focused regression coverage for policy defaults and fallback behavior

## Root Cause
The executor `PolicyClient` still defaulted to advisory `shadow` mode and `open` fallback behavior, so policy backend failures could allow execution unless operators opted into stricter settings.

## Validation
- `docker run --rm -v "$PWD:/work" -w /work python:3.11-slim bash -lc "pip install --no-cache-dir -r executor/requirements.txt >/tmp/pip.log && pytest -q executor/test_policy_client.py executor/test_api_server_execute.py"`
- `bash scripts/ci/test.sh`
- `bash scripts/ci/policy_eval_check.sh`
- `bash scripts/ci/build.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup validation enforces secure policy defaults and can block unsafe configs.

* **Configuration Changes**
  * Policy enforcement enabled by default; fail-closed by default.
  * Optional development-only override available for explicit testing.

* **Documentation**
  * Security and policy docs updated to reflect default posture and override requirements.

* **Tests**
  * Added tests covering default behavior, unsafe-config rejection, and the dev override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->