### PR TITLE
[codex] Require executor API authentication and harden request validation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -183,9 +183,11 @@ services:
 
 ## API Authentication
 
-### Optional API Key Authentication
+### Required API Key Authentication
 
-Enable API key authentication by setting the environment variable:
+The executor API requires `EXECUTOR_API_KEY` at startup. The service refuses to start if the key is missing or blank.
+
+Configure it before starting the API:
 
 ```bash
 export EXECUTOR_API_KEY="your-secure-api-key-here"
@@ -205,6 +207,19 @@ curl -X POST http://localhost:8080/execute \
     "scope": "test",
     "code": "print(\"Hello World\")"
   }'
+```
+
+### Origin and Request Validation
+
+- CORS is explicit-only. Set `EXECUTOR_ALLOWED_ORIGINS` to a comma-separated list of trusted browser origins when browser clients need access.
+- Executor POST endpoints accept only `application/json` request bodies whose top-level value is a JSON object.
+- Request bodies larger than `EXECUTOR_MAX_REQUEST_BODY_BYTES` are rejected with `413` before policy or sandbox side effects occur.
+
+Example:
+
+```bash
+export EXECUTOR_ALLOWED_ORIGINS="https://console.example.com,https://ops.example.com"
+export EXECUTOR_MAX_REQUEST_BODY_BYTES=1048576
 ```
 
 ### Production Mode

--- a/deploy-phase3.sh
+++ b/deploy-phase3.sh
@@ -12,7 +12,8 @@ echo ""
 
 # Configuration
 RUNTIME_DIR="/opt/ai-orchestrator"
-SOURCE_DIR="/home/tommy/.dev/ai-orchestrator"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="${SOURCE_DIR:-$SCRIPT_DIR}"
 
 # Colors
 RED='\033[0;31m'

--- a/docs/reports/final-verification-complete.md
+++ b/docs/reports/final-verification-complete.md
@@ -26,7 +26,7 @@ Documented all verification steps with timestamps and findings.
 **Command:**
 ```bash
 grep -r "slice(0, 1536)" /opt/ai-orchestrator/n8n/ 2>/dev/null || true
-grep -r "slice.*1536" /home/tommy/.dev/ai-orchestrator/n8n/workflows/*.json
+grep -r "slice.*1536" ./n8n/workflows/*.json
 ```
 
 **Findings:**
@@ -42,8 +42,8 @@ grep -r "slice.*1536" /home/tommy/.dev/ai-orchestrator/n8n/workflows/*.json
 ### ✅ Step 2: PCA Activation in Workflows
 
 **Workflows Updated:**
-1. `/home/tommy/.dev/ai-orchestrator/n8n/workflows/01_memory_ingest.json`
-2. `/home/tommy/.dev/ai-orchestrator/n8n/workflows/02_vector_search.json`
+1. `./n8n/workflows/01_memory_ingest.json`
+2. `./n8n/workflows/02_vector_search.json`
 
 **Changes Made:**
 
@@ -140,7 +140,7 @@ ae096d2 - feat: activate PCA reduction in workflows, configure logrotate, verify
 
 2. **Copy Updated Workflows:**
    ```bash
-   sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/*.json \
+   sudo cp ./n8n/workflows/*.json \
            /opt/ai-orchestrator/n8n/workflows-v3/
    ```
 
@@ -303,14 +303,14 @@ b495f14 - feat: Phase 2 hardening - response fixes, PCA, monitoring
 
 ```bash
 # Full deployment (run on production server)
-sudo /home/tommy/.dev/ai-orchestrator/deploy-phase3.sh
+sudo ./deploy-phase3.sh
 
 # Manual steps if needed:
 # 1. Generate PCA model
 cd /opt/ai-orchestrator/tools && python3 pca_reduce.py fit --source db --samples 5000
 
 # 2. Copy workflows
-sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/*.json /opt/ai-orchestrator/n8n/workflows-v3/
+sudo cp ./n8n/workflows/*.json /opt/ai-orchestrator/n8n/workflows-v3/
 
 # 3. Restart services
 cd /opt/ai-orchestrator && docker compose restart n8n
@@ -351,4 +351,3 @@ docker exec ai-postgres psql -U ai_user -d ai_memory -c "SELECT count(*) FROM me
 **Date:** 2026-02-14  
 **Status:** All tasks completed successfully  
 **Production Ready:** YES ✅
-

--- a/docs/reports/implementation-summary.md
+++ b/docs/reports/implementation-summary.md
@@ -236,7 +236,7 @@ const secretPatterns = [
 
 ### GitHub Repository
 ```
-/home/tommy/.dev/ai-orchestrator/
+<repo-root>/
 ├── Caddyfile                              [MODIFIED] - Added rate limiting
 ├── deploy-updates.sh                      [NEW] - Deployment automation
 ├── n8n/workflows/
@@ -263,15 +263,15 @@ Message: feat: add embedding cache, pgvector tuning, operational guards
 ### Step 1: Copy Files to Runtime
 ```bash
 # Run deployment script
-sudo /home/tommy/.dev/ai-orchestrator/deploy-updates.sh
+sudo ./deploy-updates.sh
 ```
 
 Or manually:
 ```bash
-sudo cp /home/tommy/.dev/ai-orchestrator/Caddyfile /opt/ai-orchestrator/Caddyfile
+sudo cp ./Caddyfile /opt/ai-orchestrator/Caddyfile
 sudo mkdir -p /opt/ai-orchestrator/n8n/workflows-v3
-sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/01_memory_ingest_v3_cached.json /opt/ai-orchestrator/n8n/workflows-v3/
-sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/02_vector_search.json /opt/ai-orchestrator/n8n/workflows-v3/
+sudo cp ./n8n/workflows/01_memory_ingest_v3_cached.json /opt/ai-orchestrator/n8n/workflows-v3/
+sudo cp ./n8n/workflows/02_vector_search.json /opt/ai-orchestrator/n8n/workflows-v3/
 ```
 
 ### Step 2: Reload Caddy
@@ -323,7 +323,7 @@ curl -X POST 'https://n8n-s-app01.tmcast.net/webhook/memory/search-v3' \
 | Embedding cache functional | ✅ | content_hash column, unique index, cached workflow |
 | pgvector index exists | ✅ | idx_memory_vectors_embedding (ivfflat, lists=50) |
 | Query plan verification | ✅ | Documented in work log |
-| Work logs created | ✅ | 4 work logs under /home/tommy/.dev/worklog/ai-orchestrator |
+| Work logs created | ✅ | 4 work logs under `./worklog/` |
 | No secrets in repo | ✅ | API keys only in runtime environment |
 | Rate limiting | ✅ | Caddy config: 30 req/min per IP |
 | Retry logic | ✅ | 3 retries with 1s delay on Gemini nodes |
@@ -391,7 +391,7 @@ curl -X POST 'https://n8n-s-app01.tmcast.net/webhook/memory/search-v3' \
 ## Contact & Support
 
 - **Repository:** https://github.com/TommyKammy/ai-orchestrator
-- **Work Logs:** `/home/tommy/.dev/worklog/ai-orchestrator/`
+- **Work Logs:** `./worklog/`
 - **Runtime:** `/opt/ai-orchestrator/`
 - **n8n URL:** https://n8n-s-app01.tmcast.net
 

--- a/docs/reports/phase2-summary.md
+++ b/docs/reports/phase2-summary.md
@@ -132,7 +132,7 @@ docker exec ai-postgres psql -U ai_user -d ai_memory -f monitor_pgvector.sql
 
 ### New Files
 ```
-/home/tommy/.dev/ai-orchestrator/
+<repo-root>/
 ├── tools/
 │   ├── pca_reduce.py              [NEW] PCA reduction tool
 │   ├── requirements.txt           [NEW] Python dependencies
@@ -178,16 +178,16 @@ Files: 7 files changed, 1149 insertions(+), 6 deletions(-)
 
 ### 1. Copy Updated Workflows
 ```bash
-sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/01_memory_ingest.json \
+sudo cp ./n8n/workflows/01_memory_ingest.json \
         /opt/ai-orchestrator/n8n/workflows-v3/
-sudo cp /home/tommy/.dev/ai-orchestrator/n8n/workflows/02_vector_search.json \
+sudo cp ./n8n/workflows/02_vector_search.json \
         /opt/ai-orchestrator/n8n/workflows-v3/
 ```
 
 ### 2. Copy Tools
 ```bash
 sudo mkdir -p /opt/ai-orchestrator/tools
-sudo cp /home/tommy/.dev/ai-orchestrator/tools/* \
+sudo cp ./tools/* \
         /opt/ai-orchestrator/tools/
 ```
 
@@ -272,7 +272,7 @@ docker exec ai-postgres psql -U ai_user -d ai_memory \
 
 ## Repository Status
 
-**Location:** `/home/tommy/.dev/ai-orchestrator`  
+**Location:** `<repo-root>`  
 **GitHub:** https://github.com/TommyKammy/ai-orchestrator  
 **Commits:** 2 (Phase 1 + Phase 2)
 
@@ -289,4 +289,3 @@ docker exec ai-postgres psql -U ai_user -d ai_memory \
 Production Hardening Phase 2 is complete. All workflows return proper production JSON, PCA reduction is ready for deployment, query performance is tuned, and comprehensive monitoring is in place.
 
 **System Status:** Production Ready ✅
-

--- a/docs/reports/phase3-summary.md
+++ b/docs/reports/phase3-summary.md
@@ -244,7 +244,8 @@ sudo tail /var/log/pgvector_monitor.log
 # Copy files to runtime
 sudo cp ./deploy-phase3.sh /opt/ai-orchestrator/
 sudo cp ./docker-compose.yml /opt/ai-orchestrator/
-sudo cp -r ./tools /opt/ai-orchestrator/
+sudo mkdir -p /opt/ai-orchestrator/tools
+sudo cp -r ./tools/. /opt/ai-orchestrator/tools/
 
 # Generate PCA model
 cd /opt/ai-orchestrator/tools

--- a/docs/reports/phase3-summary.md
+++ b/docs/reports/phase3-summary.md
@@ -153,7 +153,7 @@ ai-redis      Up 12 hours        6379/tcp
 
 **Usage:**
 ```bash
-sudo /home/tommy/.dev/ai-orchestrator/deploy-phase3.sh
+sudo ./deploy-phase3.sh
 ```
 
 ---
@@ -230,7 +230,7 @@ b495f14 - feat: Phase 2 hardening - response fixes, PCA, monitoring
 ### Quick Deploy
 ```bash
 # 1. Run deployment script
-sudo /home/tommy/.dev/ai-orchestrator/deploy-phase3.sh
+sudo ./deploy-phase3.sh
 
 # 2. Verify cron jobs
 crontab -l
@@ -242,9 +242,9 @@ sudo tail /var/log/pgvector_monitor.log
 ### Manual Steps (if needed)
 ```bash
 # Copy files to runtime
-sudo cp /home/tommy/.dev/ai-orchestrator/deploy-phase3.sh /opt/ai-orchestrator/
-sudo cp /home/tommy/.dev/ai-orchestrator/docker-compose.yml /opt/ai-orchestrator/
-sudo cp -r /home/tommy/.dev/ai-orchestrator/tools /opt/ai-orchestrator/
+sudo cp ./deploy-phase3.sh /opt/ai-orchestrator/
+sudo cp ./docker-compose.yml /opt/ai-orchestrator/
+sudo cp -r ./tools /opt/ai-orchestrator/
 
 # Generate PCA model
 cd /opt/ai-orchestrator/tools

--- a/docs/reports/production-certification-complete.md
+++ b/docs/reports/production-certification-complete.md
@@ -146,7 +146,7 @@ All Phase 3 deployment verifications completed successfully. The AI Orchestrator
 Execute on production server to activate automation:
 
 ```bash
-sudo /home/tommy/.dev/ai-orchestrator/deploy-phase3.sh
+sudo ./deploy-phase3.sh
 ```
 
 This will:
@@ -261,4 +261,3 @@ Execute `deploy-phase3.sh` on production server to activate full automation suit
 **END OF CERTIFICATION DOCUMENT**
 
 *This document certifies that the AI Orchestrator system has been fully implemented, tested, and verified as production-ready as of 2026-02-14 10:57 JST.*
-

--- a/executor/README.md
+++ b/executor/README.md
@@ -32,6 +32,13 @@ The AI Orchestrator Executor provides **E2B-style** secure sandbox execution for
 ### 1. Start the Executor Service
 
 ```bash
+# Required: executor API auth
+export EXECUTOR_API_KEY="change-me"
+
+# Optional: explicit browser origins and request-body cap
+export EXECUTOR_ALLOWED_ORIGINS="https://console.example.com"
+export EXECUTOR_MAX_REQUEST_BODY_BYTES=1048576
+
 # Start with Docker-in-Docker executor
 docker compose -f docker-compose.yml -f docker-compose.executor.yml up -d executor
 
@@ -45,6 +52,7 @@ curl http://localhost:8080/health
 # Direct execution
 curl -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
   -d '{
     "tenant_id": "t1",
     "scope": "user:123",
@@ -52,6 +60,11 @@ curl -X POST http://localhost:8080/execute \
     "template": "default"
   }'
 ```
+
+Notes:
+- `EXECUTOR_API_KEY` is required at startup. The API refuses to boot without it.
+- Browser access requires explicit `EXECUTOR_ALLOWED_ORIGINS`; the server no longer sends wildcard CORS headers.
+- Executor POST endpoints only accept JSON-object request bodies and reject oversized bodies with `413`.
 
 ### 3. Python SDK Example
 
@@ -151,6 +164,12 @@ Execute code in a new sandbox.
   ]
 }
 ```
+
+**Request requirements:**
+- Include `X-API-Key` on executor requests.
+- Send `Content-Type: application/json`.
+- Request body must be a JSON object.
+- Body size is capped by `EXECUTOR_MAX_REQUEST_BODY_BYTES` and returns `413` when exceeded.
 
 #### POST /session/create
 Create a persistent session.

--- a/executor/README.md
+++ b/executor/README.md
@@ -170,9 +170,23 @@ Execute code in a new sandbox.
 - Send `Content-Type: application/json`.
 - Request body must be a JSON object.
 - Body size is capped by `EXECUTOR_MAX_REQUEST_BODY_BYTES` and returns `413` when exceeded.
+- These same POST requirements apply to `/execute`, `/session/create`, `/session/execute`, and `/session/destroy`.
 
 #### POST /session/create
 Create a persistent session.
+
+**curl example:**
+```bash
+curl -X POST http://localhost:8080/session/create \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
+  -d '{
+    "tenant_id": "t1",
+    "scope": "user:123",
+    "template": "python-ml",
+    "ttl": 300
+  }'
+```
 
 **Request:**
 ```json
@@ -197,6 +211,18 @@ Create a persistent session.
 #### POST /session/execute
 Execute code in an existing session.
 
+**curl example:**
+```bash
+curl -X POST http://localhost:8080/session/execute \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
+  -d '{
+    "session_id": "abc123def456",
+    "code": "print('\''In session'\'')",
+    "language": "python"
+  }'
+```
+
 **Request:**
 ```json
 {
@@ -208,6 +234,16 @@ Execute code in an existing session.
 
 #### POST /session/destroy
 Destroy a session.
+
+**curl example:**
+```bash
+curl -X POST http://localhost:8080/session/destroy \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
+  -d '{
+    "session_id": "abc123def456"
+  }'
+```
 
 **Request:**
 ```json
@@ -357,12 +393,16 @@ sudo netstat -tlnp | grep 8080
 ```bash
 # Increase timeout
 curl -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
   -d '{
     "tenant_id": "t1",
     "scope": "test",
     "code": "...",
     "timeout": 120
   }'
+
+# Requests over EXECUTOR_MAX_REQUEST_BODY_BYTES return 413 before execution starts.
 ```
 
 ### Out of Memory
@@ -370,6 +410,8 @@ curl -X POST http://localhost:8080/execute \
 ```bash
 # Use larger template
 curl -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: change-me" \
   -d '{
     "tenant_id": "t1",
     "scope": "test",

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -421,6 +421,21 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             raise RequestValidationError(f"Field '{field}' must be an object")
         return value
 
+    def _optional_string_map_field(self, body: Dict[str, Any], field: str) -> Dict[str, str]:
+        value = self._optional_dict_field(body, field)
+        normalized: Dict[str, str] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise RequestValidationError(
+                    f"Field '{field}' must be a map of non-empty string paths to non-empty string contents"
+                )
+            if not isinstance(item, str) or not item.strip():
+                raise RequestValidationError(
+                    f"Field '{field}' must be a map of non-empty string paths to non-empty string contents"
+                )
+            normalized[key] = item
+        return normalized
+
     def _optional_int_field(self, body: Dict[str, Any], field: str, default: int) -> int:
         value = body.get(field, default)
         if isinstance(value, bool) or not isinstance(value, int):
@@ -668,7 +683,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         language = self._optional_string_field(body, 'language', 'python')
         template = self._optional_string_field(body, 'template', 'default')
         task_type = self._optional_string_field(body, 'task_type', 'code_execution')
-        files = self._optional_dict_field(body, 'files')
+        files = self._optional_string_map_field(body, 'files')
         
         # Get template configuration
         template_kwargs = template_manager.get_sandbox_kwargs(template)
@@ -812,7 +827,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         session_id = self._require_string_field(body, 'session_id')
         code = self._require_string_field(body, 'code')
         language = self._optional_string_field(body, 'language', 'python')
-        files = self._optional_dict_field(body, 'files')
+        files = self._optional_string_map_field(body, 'files')
 
         session = session_manager.get_session(session_id)
         scope = ""

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -30,7 +30,8 @@ logger = logging.getLogger(__name__)
 # Security configuration
 API_KEY = os.environ.get('EXECUTOR_API_KEY')
 PRODUCTION_MODE = os.environ.get('EXECUTOR_PRODUCTION', 'false').lower() == 'true'
-MAX_REQUEST_BODY_BYTES = int(os.environ.get('EXECUTOR_MAX_REQUEST_BODY_BYTES', 1024 * 1024))
+DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024
+MAX_REQUEST_BODY_BYTES = DEFAULT_MAX_REQUEST_BODY_BYTES
 ALLOWED_ORIGINS = tuple(
     origin.strip()
     for origin in os.environ.get("EXECUTOR_ALLOWED_ORIGINS", "").split(",")
@@ -74,8 +75,16 @@ class RequestValidationError(ValueError):
 
 def require_runtime_configuration():
     """Refuse startup without explicit executor authentication."""
+    global MAX_REQUEST_BODY_BYTES
+
     if not API_KEY or not str(API_KEY).strip():
         raise RuntimeError("EXECUTOR_API_KEY must be set before starting the executor API")
+
+    raw_max_body = os.environ.get("EXECUTOR_MAX_REQUEST_BODY_BYTES", str(MAX_REQUEST_BODY_BYTES))
+    try:
+        MAX_REQUEST_BODY_BYTES = int(raw_max_body)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("EXECUTOR_MAX_REQUEST_BODY_BYTES must be an integer greater than 0") from exc
 
     if MAX_REQUEST_BODY_BYTES <= 0:
         raise RuntimeError("EXECUTOR_MAX_REQUEST_BODY_BYTES must be greater than 0")

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -12,8 +12,7 @@ import time
 import uuid
 from typing import Dict, Any, Optional
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import parse_qs, urlparse
-import threading
+from urllib.parse import urlparse
 
 # Import our sandbox modules
 from executor.sandbox import CodeSandbox
@@ -31,6 +30,12 @@ logger = logging.getLogger(__name__)
 # Security configuration
 API_KEY = os.environ.get('EXECUTOR_API_KEY')
 PRODUCTION_MODE = os.environ.get('EXECUTOR_PRODUCTION', 'false').lower() == 'true'
+MAX_REQUEST_BODY_BYTES = int(os.environ.get('EXECUTOR_MAX_REQUEST_BODY_BYTES', 1024 * 1024))
+ALLOWED_ORIGINS = tuple(
+    origin.strip()
+    for origin in os.environ.get("EXECUTOR_ALLOWED_ORIGINS", "").split(",")
+    if origin.strip()
+)
 
 # Global session manager
 session_manager = SessionManager(
@@ -57,6 +62,23 @@ REQUEST_METRICS = {
     "statuses": {},
 }
 REQUEST_METRIC_EXCLUDE_PATHS = {"/metrics", "/metrics/prometheus", "/health"}
+
+
+class RequestValidationError(ValueError):
+    """Raised when an incoming request fails validation."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
+def require_runtime_configuration():
+    """Refuse startup without explicit executor authentication."""
+    if not API_KEY or not str(API_KEY).strip():
+        raise RuntimeError("EXECUTOR_API_KEY must be set before starting the executor API")
+
+    if MAX_REQUEST_BODY_BYTES <= 0:
+        raise RuntimeError("EXECUTOR_MAX_REQUEST_BODY_BYTES must be greater than 0")
 
 
 def sanitize_error(error: str) -> str:
@@ -217,15 +239,30 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         self.send_header('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'")
         self.send_header('Referrer-Policy', 'strict-origin-when-cross-origin')
         self.send_header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
-    
+
+    def _get_cors_origin(self) -> Optional[str]:
+        origin = self.headers.get("Origin", "").strip()
+        if not origin:
+            return None
+        if origin in ALLOWED_ORIGINS:
+            return origin
+        return None
+
+    def _send_cors_headers(self):
+        origin = self._get_cors_origin()
+        if not origin:
+            return
+        self.send_header("Access-Control-Allow-Origin", origin)
+        self.send_header("Vary", "Origin")
+
     def _send_json_response(self, data: Dict[str, Any], status: int = 200):
         """Send JSON response."""
         self.send_response(status)
         self.send_header('Content-Type', 'application/json')
-        self.send_header('Access-Control-Allow-Origin', '*')
         request_id = getattr(self, "request_id", None)
         if request_id:
             self.send_header("X-Request-ID", request_id)
+        self._send_cors_headers()
         self._send_security_headers()
         body = json.dumps(data).encode('utf-8')
         self.send_header("Content-Length", str(len(body)))
@@ -240,6 +277,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         request_id = getattr(self, "request_id", None)
         if request_id:
             self.send_header("X-Request-ID", request_id)
+        self._send_cors_headers()
         self._send_security_headers()
         body = text.encode("utf-8")
         self.send_header("Content-Length", str(len(body)))
@@ -326,15 +364,70 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _read_body(self) -> Dict[str, Any]:
         """Read and parse request body."""
-        content_length = int(self.headers.get('Content-Length', 0))
+        content_length_header = self.headers.get('Content-Length', '0')
+        try:
+            content_length = int(content_length_header)
+        except ValueError as exc:
+            raise RequestValidationError("Invalid Content-Length header") from exc
+        if content_length < 0:
+            raise RequestValidationError("Invalid Content-Length header")
+        if content_length > MAX_REQUEST_BODY_BYTES:
+            raise RequestValidationError("Request body too large", status=413)
         if content_length == 0:
             return {}
-        
-        body = self.rfile.read(content_length).decode('utf-8')
+
+        content_type = self.headers.get("Content-Type", "")
+        if not content_type.lower().startswith("application/json"):
+            raise RequestValidationError("Content-Type must be application/json", status=415)
+
+        raw_body = self.rfile.read(content_length)
+        if len(raw_body) > MAX_REQUEST_BODY_BYTES:
+            raise RequestValidationError("Request body too large", status=413)
+
         try:
-            return json.loads(body)
-        except json.JSONDecodeError:
+            body = json.loads(raw_body.decode('utf-8'))
+        except UnicodeDecodeError as exc:
+            raise RequestValidationError("Request body must be valid UTF-8") from exc
+        except json.JSONDecodeError as exc:
+            raise RequestValidationError("Request body must be valid JSON") from exc
+
+        if not isinstance(body, dict):
+            raise RequestValidationError("Request body must be a JSON object")
+
+        return body
+
+    def _require_string_field(self, body: Dict[str, Any], field: str) -> str:
+        value = body.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise RequestValidationError(f"Field '{field}' must be a non-empty string")
+        return value
+
+    def _require_fields_present(self, body: Dict[str, Any], *fields: str):
+        missing = [field for field in fields if body.get(field) is None]
+        if missing:
+            raise RequestValidationError(f"Missing required fields: {', '.join(missing)}")
+
+    def _optional_string_field(self, body: Dict[str, Any], field: str, default: str) -> str:
+        value = body.get(field, default)
+        if not isinstance(value, str) or not value.strip():
+            raise RequestValidationError(f"Field '{field}' must be a non-empty string")
+        return value
+
+    def _optional_dict_field(self, body: Dict[str, Any], field: str) -> Dict[str, Any]:
+        value = body.get(field, {})
+        if value is None:
             return {}
+        if not isinstance(value, dict):
+            raise RequestValidationError(f"Field '{field}' must be an object")
+        return value
+
+    def _optional_int_field(self, body: Dict[str, Any], field: str, default: int) -> int:
+        value = body.get(field, default)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise RequestValidationError(f"Field '{field}' must be an integer")
+        if value <= 0:
+            raise RequestValidationError(f"Field '{field}' must be greater than 0")
+        return value
     
     def do_OPTIONS(self):
         """Handle CORS preflight requests."""
@@ -345,10 +438,17 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         self._request_started = time.monotonic()
         self.response_status_code = 0
 
+        origin = self._get_cors_origin()
+        if not origin:
+            self._send_error("Origin not allowed", 403)
+            self._log_access("OPTIONS", path)
+            return
+
         self.send_response(200)
-        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Origin', origin)
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
         self.send_header('Access-Control-Allow-Headers', 'Content-Type, X-API-Key, X-Request-ID')
+        self.send_header('Vary', 'Origin')
         self.send_header("X-Request-ID", self.request_id)
         self._send_security_headers()
         self.end_headers()
@@ -400,6 +500,8 @@ class ExecutorHandler(BaseHTTPRequestHandler):
                 return
             body = self._read_body()
             self._dispatch_post(path, body)
+        except RequestValidationError as e:
+            self._send_error(str(e), e.status)
         except Exception as e:
             self._log_json(
                 "error",
@@ -559,19 +661,14 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_execute(self, body: Dict[str, Any]):
         """Handle direct code execution."""
-        tenant_id = body.get('tenant_id')
-        scope = body.get('scope')
-        code = body.get('code')
-        language = body.get('language', 'python')
-        template = body.get('template', 'default')
-        task_type = body.get('task_type', 'code_execution')
-        files = body.get('files', {})
-        
-        if not all([tenant_id, scope, code]):
-            self._send_error("Missing required fields: tenant_id, scope, code")
-            return
-        
-        code = str(code)  # Ensure code is string
+        self._require_fields_present(body, 'tenant_id', 'scope', 'code')
+        tenant_id = self._require_string_field(body, 'tenant_id')
+        scope = self._require_string_field(body, 'scope')
+        code = self._require_string_field(body, 'code')
+        language = self._optional_string_field(body, 'language', 'python')
+        template = self._optional_string_field(body, 'template', 'default')
+        task_type = self._optional_string_field(body, 'task_type', 'code_execution')
+        files = self._optional_dict_field(body, 'files')
         
         # Get template configuration
         template_kwargs = template_manager.get_sandbox_kwargs(template)
@@ -632,14 +729,11 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_create_session(self, body: Dict[str, Any]):
         """Handle session creation."""
-        tenant_id = body.get('tenant_id')
-        scope = body.get('scope')
-        template = body.get('template', 'default')
-        ttl = body.get('ttl', 300)
-        
-        if not all([tenant_id, scope]):
-            self._send_error("Missing required fields: tenant_id, scope")
-            return
+        self._require_fields_present(body, 'tenant_id', 'scope')
+        tenant_id = self._require_string_field(body, 'tenant_id')
+        scope = self._require_string_field(body, 'scope')
+        template = self._optional_string_field(body, 'template', 'default')
+        ttl = self._optional_int_field(body, 'ttl', 300)
         
         try:
             # Get template configuration
@@ -691,11 +785,8 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_destroy_session(self, body: Dict[str, Any]):
         """Handle session destruction."""
-        session_id = body.get('session_id')
-        
-        if not session_id:
-            self._send_error("Missing required field: session_id")
-            return
+        self._require_fields_present(body, 'session_id')
+        session_id = self._require_string_field(body, 'session_id')
         
         success = session_manager.destroy_session(session_id)
         
@@ -717,14 +808,11 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_session_execute(self, body: Dict[str, Any]):
         """Handle execution in existing session."""
-        session_id = body.get('session_id')
-        code = body.get('code')
-        language = body.get('language', 'python')
-        files = body.get('files', {})
-        
-        if not all([session_id, code]):
-            self._send_error("Missing required fields: session_id, code")
-            return
+        self._require_fields_present(body, 'session_id', 'code')
+        session_id = self._require_string_field(body, 'session_id')
+        code = self._require_string_field(body, 'code')
+        language = self._optional_string_field(body, 'language', 'python')
+        files = self._optional_dict_field(body, 'files')
 
         session = session_manager.get_session(session_id)
         scope = ""
@@ -774,6 +862,7 @@ def start_server(host: str = '0.0.0.0', port: int = 8080):
         host: Host to bind to
         port: Port to listen on
     """
+    require_runtime_configuration()
     server = HTTPServer((host, port), ExecutorHandler)
     logger.info(f"Executor API server started on {host}:{port}")
     

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -173,14 +173,18 @@ def test_import_api_server_does_not_crash_on_invalid_max_request_body_env():
     env = os.environ.copy()
     env["EXECUTOR_MAX_REQUEST_BODY_BYTES"] = "not-an-int"
     repo_root = Path(__file__).resolve().parents[1]
-    result = subprocess.run(
-        [sys.executable, "-c", "import executor.api_server; print('imported')"],
-        capture_output=True,
-        cwd=repo_root,
-        env=env,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import executor.api_server; print('imported')"],
+            capture_output=True,
+            cwd=repo_root,
+            env=env,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"Import probe timed out after {exc.timeout} seconds")
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "imported"

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -160,8 +160,8 @@ def test_start_server_requires_executor_api_key():
 
 
 def test_start_server_rejects_invalid_max_request_body_bytes():
-    with patch("executor.api_server.API_KEY", "secret-key"), patch(
-        "executor.api_server.MAX_REQUEST_BODY_BYTES", "not-an-int"
+    with patch("executor.api_server.API_KEY", "secret-key"), patch.dict(
+        os.environ, {"EXECUTOR_MAX_REQUEST_BODY_BYTES": "not-an-int"}, clear=False
     ), patch("executor.api_server.HTTPServer") as http_server:
         with pytest.raises(RuntimeError, match="EXECUTOR_MAX_REQUEST_BODY_BYTES must be an integer"):
             start_server(host="127.0.0.1", port=0)

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -1,8 +1,12 @@
 import http.client
 import json
 import logging
+import os
+import subprocess
+import sys
 import threading
 from http.server import HTTPServer
+from pathlib import Path
 from typing import Optional
 from unittest.mock import Mock, patch
 
@@ -153,6 +157,33 @@ def test_start_server_requires_executor_api_key():
             start_server(host="127.0.0.1", port=0)
 
     http_server.assert_not_called()
+
+
+def test_start_server_rejects_invalid_max_request_body_bytes():
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.MAX_REQUEST_BODY_BYTES", "not-an-int"
+    ), patch("executor.api_server.HTTPServer") as http_server:
+        with pytest.raises(RuntimeError, match="EXECUTOR_MAX_REQUEST_BODY_BYTES must be an integer"):
+            start_server(host="127.0.0.1", port=0)
+
+    http_server.assert_not_called()
+
+
+def test_import_api_server_does_not_crash_on_invalid_max_request_body_env():
+    env = os.environ.copy()
+    env["EXECUTOR_MAX_REQUEST_BODY_BYTES"] = "not-an-int"
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-c", "import executor.api_server; print('imported')"],
+        capture_output=True,
+        cwd=repo_root,
+        env=env,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "imported"
 
 
 def test_execute_requires_api_key_header_when_configured():

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -152,7 +152,10 @@ def test_execute_returns_structured_output():
 
 
 def test_start_server_requires_executor_api_key():
-    with patch("executor.api_server.API_KEY", None), patch("executor.api_server.HTTPServer") as http_server:
+    with patch.dict(os.environ, {}, clear=False), patch(
+        "executor.api_server.API_KEY", None
+    ), patch("executor.api_server.HTTPServer") as http_server:
+        os.environ.pop("EXECUTOR_API_KEY", None)
         with pytest.raises(RuntimeError, match="EXECUTOR_API_KEY"):
             start_server(host="127.0.0.1", port=0)
 
@@ -191,7 +194,9 @@ def test_import_api_server_does_not_crash_on_invalid_max_request_body_env():
 
 
 def test_execute_requires_api_key_header_when_configured():
-    with patch("executor.api_server.API_KEY", "secret-key"):
+    with patch.dict(os.environ, {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+        "executor.api_server.API_KEY", "secret-key"
+    ):
         server, thread = _start_server()
         try:
             status, payload = _post_json(
@@ -210,7 +215,9 @@ def test_execute_requires_api_key_header_when_configured():
 
 
 def test_execute_succeeds_with_api_key_header_when_configured():
-    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+    with patch.dict(os.environ, {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+        "executor.api_server.API_KEY", "secret-key"
+    ), patch(
         "executor.api_server.template_manager.get_sandbox_kwargs", return_value={}
     ), patch(
         "executor.api_server.policy_client.evaluate",

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -237,6 +237,37 @@ def test_execute_rejects_oversized_body_before_sandbox_run():
     sandbox_cls.assert_not_called()
 
 
+def test_execute_rejects_invalid_files_map_before_side_effects():
+    with patch("executor.api_server.API_KEY", None), patch(
+        "executor.api_server.policy_client.evaluate"
+    ) as evaluate_mock, patch("executor.api_server.policy_client.enforce") as enforce_mock, patch(
+        "executor.api_server.CodeSandbox"
+    ) as sandbox_cls:
+        server, thread = _start_server()
+        try:
+            status, payload = _post_json(
+                server.server_port,
+                "/execute",
+                {
+                    "tenant_id": "t1",
+                    "scope": "analysis",
+                    "code": "print('ok')",
+                    "files": {"a.txt": {"nested": 1}},
+                },
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 400
+    assert payload["status"] == "error"
+    assert "files" in payload["error"]
+    evaluate_mock.assert_not_called()
+    enforce_mock.assert_not_called()
+    sandbox_cls.assert_not_called()
+
+
 def test_request_id_is_echoed_in_response_header():
     with patch("executor.api_server.API_KEY", None), patch(
         "executor.api_server.template_manager.get_sandbox_kwargs", return_value={}

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -6,7 +6,10 @@ from http.server import HTTPServer
 from typing import Optional
 from unittest.mock import Mock, patch
 
+import pytest
+
 from executor.api_server import ExecutorHandler
+from executor.api_server import start_server
 
 
 class _FakeSandbox:
@@ -144,6 +147,96 @@ def test_execute_returns_structured_output():
     assert payload["result"]["stdout"] == "ok"
 
 
+def test_start_server_requires_executor_api_key():
+    with patch("executor.api_server.API_KEY", None), patch("executor.api_server.HTTPServer") as http_server:
+        with pytest.raises(RuntimeError, match="EXECUTOR_API_KEY"):
+            start_server(host="127.0.0.1", port=0)
+
+    http_server.assert_not_called()
+
+
+def test_execute_requires_api_key_header_when_configured():
+    with patch("executor.api_server.API_KEY", "secret-key"):
+        server, thread = _start_server()
+        try:
+            status, payload = _post_json(
+                server.server_port,
+                "/execute",
+                {"tenant_id": "t1", "scope": "analysis", "code": "print('ok')", "language": "python"},
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 401
+    assert payload["status"] == "error"
+    assert payload["error"] == "Unauthorized"
+
+
+def test_execute_succeeds_with_api_key_header_when_configured():
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.template_manager.get_sandbox_kwargs", return_value={}
+    ), patch(
+        "executor.api_server.policy_client.evaluate",
+        return_value={
+            "decision": "allow",
+            "allow": True,
+            "requires_approval": False,
+            "risk_score": 0,
+            "reasons": [],
+        },
+    ), patch("executor.api_server.policy_client.enforce", return_value=True), patch(
+        "executor.api_server.CodeSandbox", _FakeSandbox
+    ):
+        server, thread = _start_server()
+        try:
+            status, payload, _headers = _post_json_raw(
+                server.server_port,
+                "/execute",
+                {"tenant_id": "t1", "scope": "analysis", "code": "print('ok')", "language": "python"},
+                {"X-API-Key": "secret-key"},
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["status"] == "success"
+    assert payload["tenant_id"] == "t1"
+    assert payload["scope"] == "analysis"
+    assert payload["result"]["stdout"] == "ok"
+
+
+def test_execute_rejects_oversized_body_before_sandbox_run():
+    oversized_code = "x" * 128
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.MAX_REQUEST_BODY_BYTES", 64, create=True
+    ), patch("executor.api_server.policy_client.evaluate") as evaluate_mock, patch(
+        "executor.api_server.policy_client.enforce"
+    ) as enforce_mock, patch("executor.api_server.CodeSandbox") as sandbox_cls:
+        server, thread = _start_server()
+        try:
+            status, payload, _headers = _post_json_raw(
+                server.server_port,
+                "/execute",
+                {"tenant_id": "t1", "scope": "analysis", "code": oversized_code, "language": "python"},
+                {"X-API-Key": "secret-key"},
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 413
+    assert payload["status"] == "error"
+    assert "too large" in payload["error"].lower()
+    evaluate_mock.assert_not_called()
+    enforce_mock.assert_not_called()
+    sandbox_cls.assert_not_called()
+
+
 def test_request_id_is_echoed_in_response_header():
     with patch("executor.api_server.API_KEY", None), patch(
         "executor.api_server.template_manager.get_sandbox_kwargs", return_value={}
@@ -228,10 +321,16 @@ def test_execute_emits_structured_request_log(caplog):
 
 
 def test_options_echoes_request_id_header():
-    with patch("executor.api_server.API_KEY", None):
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.ALLOWED_ORIGINS", ("https://console.example.com",), create=True
+    ):
         server, thread = _start_server()
         try:
-            status, headers = _options(server.server_port, "/execute", {"X-Request-ID": "opt-req-1"})
+            status, headers = _options(
+                server.server_port,
+                "/execute",
+                {"Origin": "https://console.example.com", "X-Request-ID": "opt-req-1"},
+            )
         finally:
             server.shutdown()
             server.server_close()
@@ -239,6 +338,7 @@ def test_options_echoes_request_id_header():
 
     assert status == 200
     assert headers["X-Request-ID"] == "opt-req-1"
+    assert headers["Access-Control-Allow-Origin"] == "https://console.example.com"
     assert headers["Access-Control-Allow-Headers"] == "Content-Type, X-API-Key, X-Request-ID"
 
 

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -171,6 +171,42 @@ def test_session_create_policy_denied_returns_403_without_creating_session():
         manager.stop()
 
 
+def test_session_execute_rejects_invalid_files_map_before_side_effects():
+    manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
+    try:
+        with patch("executor.api_server.API_KEY", None), patch(
+            "executor.api_server.session_manager", manager
+        ), patch(
+            "executor.api_server.policy_client.evaluate"
+        ) as evaluate_mock, patch("executor.api_server.policy_client.enforce") as enforce_mock, patch(
+            "executor.api_server.session_manager.execute_in_session"
+        ) as execute_mock:
+            server, thread = _start_server()
+            try:
+                status, payload = _post_json(
+                    server.server_port,
+                    "/session/execute",
+                    {
+                        "session_id": "abc123def456",
+                        "code": "print('ok')",
+                        "files": {"a.txt": {"nested": 1}},
+                    },
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+        assert status == 400
+        assert payload["status"] == "error"
+        assert "files" in payload["error"]
+        evaluate_mock.assert_not_called()
+        enforce_mock.assert_not_called()
+        execute_mock.assert_not_called()
+    finally:
+        manager.stop()
+
+
 def test_session_manager_persists_ttl_state_with_store():
     state_store = _FakeStateStore()
     manager = SessionManager(

--- a/scripts/credential-setup-helper.sh
+++ b/scripts/credential-setup-helper.sh
@@ -7,7 +7,10 @@ echo "Credentials need to be recreated in n8n UI."
 echo "URL: https://n8n-s-app01.tmcast.net/credentials"
 echo ""
 
-cd /opt/ai-orchestrator 2>/dev/null || cd /home/tommy/.dev/ai-orchestrator
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd /opt/ai-orchestrator 2>/dev/null || cd "$REPO_DIR"
 
 echo "=== Required Credentials ==="
 echo ""

--- a/scripts/credential-setup-helper.sh
+++ b/scripts/credential-setup-helper.sh
@@ -10,7 +10,10 @@ echo ""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-cd /opt/ai-orchestrator 2>/dev/null || cd "$REPO_DIR"
+cd /opt/ai-orchestrator 2>/dev/null || cd "$REPO_DIR" || {
+    echo "Error: unable to locate repository directory" >&2
+    exit 1
+}
 
 echo "=== Required Credentials ==="
 echo ""

--- a/scripts/safe-push.sh
+++ b/scripts/safe-push.sh
@@ -11,8 +11,9 @@
 set -euo pipefail
 
 # Configuration
-REPO_DIR="/home/tommy/.dev/ai-orchestrator"
-WORKLOG_DIR="/home/tommy/.dev/worklog/ai-orchestrator"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+WORKLOG_DIR="${WORKLOG_DIR:-${REPO_DIR}/worklog}"
 WORKFLOW_DIR="n8n/workflows-v3"
 
 # Colors for output


### PR DESCRIPTION
## Summary
- require `EXECUTOR_API_KEY` before the executor API will start
- replace wildcard CORS with explicit allowed-origin handling and add bounded JSON request validation
- document the new executor auth, origin, and body-size requirements

## Why
The executor API previously allowed permissive startup and request handling that did not match the hardening expected for executor-facing endpoints. This change closes the auth-by-default gap and rejects unsafe request shapes before policy or sandbox side effects occur.

## Impact
- executor deployments must set `EXECUTOR_API_KEY`
- browser clients must use origins listed in `EXECUTOR_ALLOWED_ORIGINS`
- oversized POST bodies are rejected with `413`
- authenticated callers keep the same endpoint contract on success paths

## Validation
- `docker run --rm -v "$PWD:/work" -w /work python:3.11-slim bash -lc "pip install --no-cache-dir -r executor/requirements.txt >/tmp/pip.log && pytest -q executor/test_api_server_execute.py executor/test_api_server_session_lifecycle.py"`
- `bash scripts/ci/test.sh`
- `bash scripts/ci/build.sh`
- manual unauthenticated `POST /execute` probe returned `401`

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Executor now requires an API key, enforces explicit CORS origins, accepts only JSON-object POST bodies, and applies a configurable request-size limit (requests over the limit return 413).

* **Documentation**
  * Updated deployment and executor docs with required env vars, startup guidance, request requirements, examples, and repo-relative paths.

* **Tests**
  * Added tests for startup validation, auth, CORS/OPTIONS, body-size rejection, and request-field/schema validation.

* **Chores**
  * Deployment and helper scripts now use repository-relative paths for portability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->