### PR TITLE
[codex] Harden policy bundle publication auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ POLICY_REGISTRY_DB_PASSWORD=CHANGE_ME
 
 # Publish endpoint auth token (n8n CE workflows)
 POLICY_PUBLISH_TOKEN=CHANGE_ME
+
+# Policy bundle server runtime publish auth
+POLICY_BUNDLE_PUBLISH_API_KEY=CHANGE_ME

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ At minimum configure these in `.env`:
 - `N8N_WEBHOOK_API_KEY`
 - `SLACK_INTERNAL_AUTH`
 - `N8N_HOST`
+- `POLICY_BUNDLE_PUBLISH_API_KEY`
 
 Reference: `.env.example`
 

--- a/docker/policy-bundle-server/server.py
+++ b/docker/policy-bundle-server/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import io
 import json
+import logging
 import mimetypes
 import os
 import tarfile
@@ -18,6 +19,10 @@ N8N_INTERNAL_BASE_URL = os.environ.get("N8N_INTERNAL_BASE_URL", "http://n8n:5678
 UI_ROOT = os.path.join(os.path.dirname(__file__), "ui")
 HOST = os.environ.get("BUNDLE_SERVER_HOST", "0.0.0.0")
 PORT = int(os.environ.get("BUNDLE_SERVER_PORT", "8088"))
+PUBLISH_API_KEY = os.environ.get("POLICY_BUNDLE_PUBLISH_API_KEY", "").strip()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("policy_bundle_server")
 
 
 def _read_text(path, fallback=""):
@@ -126,6 +131,67 @@ def build_bundle_bytes():
 
 
 class Handler(BaseHTTPRequestHandler):
+    def _log_json(self, level, payload):
+        log_fn = getattr(logger, level, logger.info)
+        log_fn(json.dumps(payload, sort_keys=True))
+
+    def _publish_log_context(self, status, payload=None, **extra):
+        actor = ""
+        revision_id = ""
+        workflow_count = None
+        if isinstance(payload, dict):
+            actor = str(payload.get("actor", "")).strip()
+            revision_id = str(payload.get("revision_id", "")).strip()
+            workflows = payload.get("workflows")
+            if isinstance(workflows, list):
+                workflow_count = len(workflows)
+
+        event = {
+            "event": "policy_publish",
+            "method": getattr(self, "command", ""),
+            "path": getattr(self, "path", ""),
+            "source_ip": self.client_address[0] if getattr(self, "client_address", None) else "",
+            "status": status,
+        }
+        if actor:
+            event["actor"] = actor
+        if revision_id:
+            event["revision_id"] = revision_id
+        if workflow_count is not None:
+            event["workflow_count"] = workflow_count
+        event.update(extra)
+        return event
+
+    def _require_publish_auth(self, payload=None):
+        if not PUBLISH_API_KEY:
+            self._log_json(
+                "error",
+                self._publish_log_context(
+                    503,
+                    payload,
+                    outcome="rejected",
+                    reason="publish_auth_not_configured",
+                ),
+            )
+            self._send_json(503, {"ok": False, "error": "Publish authentication not configured"})
+            return False
+
+        auth_header = self.headers.get("X-API-Key", "").strip()
+        if auth_header == PUBLISH_API_KEY:
+            return True
+
+        self._log_json(
+            "warning",
+            self._publish_log_context(
+                401,
+                payload,
+                outcome="rejected",
+                reason="invalid_api_key",
+            ),
+        )
+        self._send_json(401, {"ok": False, "error": "Unauthorized"})
+        return False
+
     def _send_json(self, status, payload):
         body = json.dumps(payload, ensure_ascii=True).encode("utf-8")
         self.send_response(status)
@@ -145,6 +211,9 @@ class Handler(BaseHTTPRequestHandler):
         payload, err = _read_body_json(self)
         if err:
             self._send_json(400, {"ok": False, "error": err})
+            return
+
+        if not self._require_publish_auth(payload):
             return
 
         workflows = payload.get("workflows")
@@ -167,6 +236,15 @@ class Handler(BaseHTTPRequestHandler):
             f.write("\n")
         os.replace(tmp_path, RUNTIME_REGISTRY_PATH)
 
+        self._log_json(
+            "info",
+            self._publish_log_context(
+                200,
+                runtime_payload,
+                outcome="applied",
+                notes=str(runtime_payload.get("notes", "")),
+            ),
+        )
         self._send_json(200, {"ok": True, "revision_id": runtime_payload["revision_id"], "count": len(workflows)})
 
     def _serve_ui_asset(self, path):
@@ -231,7 +309,20 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if path == "/policy-ui/api/publish":
+            if not self._require_publish_auth(payload):
+                return
             status, response = _proxy_n8n_json("POST", "/webhook/policy/registry/publish", body=payload)
+            log_level = "info" if 200 <= status < 400 else "warning"
+            self._log_json(
+                log_level,
+                self._publish_log_context(
+                    status,
+                    payload,
+                    outcome="proxied" if 200 <= status < 400 else "rejected",
+                    upstream="n8n",
+                    upstream_response_ok=bool(response.get("ok")) if isinstance(response, dict) else False,
+                ),
+            )
             self._send_json(status, response)
             return
 

--- a/docker/policy-bundle-server/ui/app.js
+++ b/docker/policy-bundle-server/ui/app.js
@@ -9,6 +9,7 @@ const taskTypeOptions = $("#taskTypeOptions");
 const workflowOptions = $("#workflowOptions");
 const taskTypeFromWorkflow = $("#taskTypeFromWorkflow");
 const taskTypeFromPolicy = $("#taskTypeFromPolicy");
+const publishApiKeyInput = $("#publishApiKey");
 
 let allRules = [];
 
@@ -130,11 +131,12 @@ async function apiGet(path) {
   return json;
 }
 
-async function apiPost(path, payload) {
+async function apiPost(path, payload, options = {}) {
+  const headers = { "Content-Type": "application/json", ...(options.headers || {}) };
   const res = await fetch(path, {
     method: "POST",
     credentials: "same-origin",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload),
   });
   const json = await res.json().catch(() => ({ error: "invalid json response" }));
@@ -237,6 +239,12 @@ taskTypeFromPolicy?.addEventListener("change", () => {
 $("#publishForm").addEventListener("submit", async (e) => {
   e.preventDefault();
   const f = e.currentTarget;
+  const publishApiKey = (publishApiKeyInput?.value || "").trim();
+  if (!publishApiKey) {
+    setResult({ ok: false, action: "publish", error: { error: "publish_api_key is required" } });
+    publishApiKeyInput?.focus();
+    return;
+  }
 
   const payload = {
     revision_id: f.revision_id.value.trim(),
@@ -262,7 +270,10 @@ $("#publishForm").addEventListener("submit", async (e) => {
 
     if (!confirm(msg)) return;
 
-    const result = await apiPost("/policy-ui/api/publish", payload);
+    sessionStorage.setItem("policyUiPublishApiKey", publishApiKey);
+    const result = await apiPost("/policy-ui/api/publish", payload, {
+      headers: { "X-API-Key": publishApiKey },
+    });
 
     // Reflection check (OPA polling interval is up to 30 seconds)
     let reflected = false;
@@ -317,6 +328,9 @@ $("#refreshAll").addEventListener("click", async () => {
 
 (async () => {
   try {
+    if (publishApiKeyInput) {
+      publishApiKeyInput.value = sessionStorage.getItem("policyUiPublishApiKey") || "";
+    }
     await Promise.all([loadRules(), loadRuntime(), loadCandidates()]);
     const form = $("#upsertForm");
     setAdvancedVisibility(form);

--- a/docker/policy-bundle-server/ui/app.js
+++ b/docker/policy-bundle-server/ui/app.js
@@ -270,7 +270,6 @@ $("#publishForm").addEventListener("submit", async (e) => {
 
     if (!confirm(msg)) return;
 
-    sessionStorage.setItem("policyUiPublishApiKey", publishApiKey);
     const result = await apiPost("/policy-ui/api/publish", payload, {
       headers: { "X-API-Key": publishApiKey },
     });
@@ -328,9 +327,6 @@ $("#refreshAll").addEventListener("click", async () => {
 
 (async () => {
   try {
-    if (publishApiKeyInput) {
-      publishApiKeyInput.value = sessionStorage.getItem("policyUiPublishApiKey") || "";
-    }
     await Promise.all([loadRules(), loadRuntime(), loadCandidates()]);
     const form = $("#upsertForm");
     setAdvancedVisibility(form);

--- a/docker/policy-bundle-server/ui/index.html
+++ b/docker/policy-bundle-server/ui/index.html
@@ -99,6 +99,7 @@
         <form id="publishForm" class="form-grid">
           <label>revision_id<input name="revision_id" placeholder="rev-YYYYMMDD-01" required /></label>
           <label>actor<input name="actor" value="policy-ui" required /></label>
+          <label class="span-2">publish_api_key<input id="publishApiKey" name="publish_api_key" type="password" autocomplete="current-password" placeholder="POLICY_BUNDLE_PUBLISH_API_KEY" required /></label>
           <label class="span-2">notes<textarea name="notes" rows="3">publish from policy ui</textarea></label>
           <button class="btn btn-warn" type="submit">Publish</button>
         </form>

--- a/docs/policy-registry-operations.md
+++ b/docs/policy-registry-operations.md
@@ -13,6 +13,7 @@ This runbook covers operational steps for policy registry workflows:
 - `policy_workflows`, `policy_revisions`, `policy_publish_logs` tables exist
 - `policy-bundle-server` and `opa` services are healthy
 - Caddy webhook API key is available (`X-API-Key`)
+- Policy bundle publish API key is configured on `policy-bundle-server` (`POLICY_BUNDLE_PUBLISH_API_KEY`)
 - Baseline policy includes `security_digest_mail` in `policy/opa/data.json`
 
 ## Standard Flow
@@ -58,6 +59,31 @@ Note:
 - Publish calls use retry/timeout protection (30s timeout, retries enabled).
 - OPA reflection remains asynchronous; validate after 10-30 seconds.
 
+### 2a) Runtime bundle publish authentication
+Direct runtime registry updates now require the policy bundle publish key in `X-API-Key`.
+
+Example:
+```bash
+curl -sS -X POST http://127.0.0.1:8088/registry/publish \
+  -H 'Content-Type: application/json' \
+  -H "X-API-Key: ${POLICY_BUNDLE_PUBLISH_API_KEY}" \
+  -d '{
+    "revision_id": "rev-20260222-01",
+    "actor": "ops",
+    "notes": "publish by operations",
+    "workflows": [{"workflow_id": "daily_it_security_digest_mailer_executor_v1", "task_type": "security_digest_mail"}]
+  }'
+```
+
+Expected response:
+- `ok: true`
+- `revision_id` matches request
+- `count` matches published workflow count
+
+Audit log expectations:
+- successful and rejected publish attempts emit structured `policy_publish` log entries from `policy-bundle-server`
+- log entries include at least request path, status, actor when supplied, and workflow count when available
+
 ### 3) Verify runtime registry
 Check bundle-server current registry:
 - `GET /registry/current`
@@ -87,4 +113,4 @@ Query policy decision endpoint and confirm expected decision.
   - `POST /policy-ui/api/publish`
   - `GET /policy-ui/api/current`
 - Candidate dropdowns (`task_type`, optional `workflow_id`) are sourced from `10_policy_registry_candidates`.
-- Browser does not need direct webhook API key handling for these operations.
+- Publish from the UI now requires the operator to supply `POLICY_BUNDLE_PUBLISH_API_KEY`; the browser sends it as `X-API-Key` only for `POST /policy-ui/api/publish`.

--- a/tests/test_policy_bundle_server.py
+++ b/tests/test_policy_bundle_server.py
@@ -1,0 +1,184 @@
+import http.client
+import importlib.util
+import io
+import json
+import tarfile
+import threading
+import unittest
+from http.server import HTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "docker" / "policy-bundle-server" / "server.py"
+)
+SPEC = importlib.util.spec_from_file_location("policy_bundle_server", MODULE_PATH)
+policy_bundle_server = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(policy_bundle_server)
+
+
+def _start_server():
+    server = HTTPServer(("127.0.0.1", 0), policy_bundle_server.Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def _post_json(port, path, payload, headers=None):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    request_headers = {"Content-Type": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    conn.request("POST", path, body=json.dumps(payload), headers=request_headers)
+    response = conn.getresponse()
+    body = response.read().decode("utf-8")
+    conn.close()
+    return response.status, json.loads(body)
+
+
+def _get_bytes(port, path):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("GET", path)
+    response = conn.getresponse()
+    body = response.read()
+    headers = dict(response.getheaders())
+    conn.close()
+    return response.status, body, headers
+
+
+class PolicyBundleServerTests(unittest.TestCase):
+    def setUp(self):
+        self._tempdir = TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+        self.tmp_path = Path(self._tempdir.name)
+        self.source_dir = self.tmp_path / "policy-source"
+        self.runtime_dir = self.tmp_path / "policy-runtime"
+        self.source_dir.mkdir()
+        self.runtime_dir.mkdir()
+        (self.source_dir / "data.json").write_text('{"policy": {}}', encoding="utf-8")
+        self.registry_path = self.runtime_dir / "policy_registry.json"
+
+        self.original_source_dir = policy_bundle_server.POLICY_SOURCE_DIR
+        self.original_runtime_dir = policy_bundle_server.POLICY_RUNTIME_DIR
+        self.original_registry_path = policy_bundle_server.RUNTIME_REGISTRY_PATH
+        self.original_publish_api_key = getattr(policy_bundle_server, "PUBLISH_API_KEY", None)
+
+        policy_bundle_server.POLICY_SOURCE_DIR = str(self.source_dir)
+        policy_bundle_server.POLICY_RUNTIME_DIR = str(self.runtime_dir)
+        policy_bundle_server.RUNTIME_REGISTRY_PATH = str(self.registry_path)
+
+        self.addCleanup(self._restore_module_globals)
+
+    def _restore_module_globals(self):
+        policy_bundle_server.POLICY_SOURCE_DIR = self.original_source_dir
+        policy_bundle_server.POLICY_RUNTIME_DIR = self.original_runtime_dir
+        policy_bundle_server.RUNTIME_REGISTRY_PATH = self.original_registry_path
+        if self.original_publish_api_key is None and hasattr(policy_bundle_server, "PUBLISH_API_KEY"):
+            delattr(policy_bundle_server, "PUBLISH_API_KEY")
+        else:
+            policy_bundle_server.PUBLISH_API_KEY = self.original_publish_api_key
+
+    def test_registry_publish_requires_api_key(self):
+        policy_bundle_server.PUBLISH_API_KEY = "publish-secret"
+        server, thread = _start_server()
+        self.addCleanup(server.shutdown)
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join, 2)
+
+        status, payload = _post_json(
+            server.server_port,
+            "/registry/publish",
+            {"workflows": [{"workflow_id": "wf-1", "task_type": "analysis"}]},
+        )
+
+        self.assertEqual(status, 401)
+        self.assertEqual(payload["ok"], False)
+        self.assertEqual(payload["error"], "Unauthorized")
+        self.assertFalse(self.registry_path.exists())
+
+    def test_registry_publish_with_api_key_updates_runtime_and_bundle_metadata(self):
+        policy_bundle_server.PUBLISH_API_KEY = "publish-secret"
+
+        server, thread = _start_server()
+        self.addCleanup(server.shutdown)
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join, 2)
+
+        with self.assertLogs("policy_bundle_server", level="INFO") as captured_logs:
+            status, payload = _post_json(
+                server.server_port,
+                "/registry/publish",
+                {
+                    "revision_id": "rev-123",
+                    "actor": "operator@example.com",
+                    "notes": "rotate policy bundle",
+                    "workflows": [{"workflow_id": "wf-1", "task_type": "analysis"}],
+                },
+                headers={"X-API-Key": "publish-secret"},
+            )
+            bundle_status, bundle_body, bundle_headers = _get_bytes(
+                server.server_port, "/bundles/policy.tar.gz"
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"ok": True, "revision_id": "rev-123", "count": 1})
+
+        runtime_payload = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        self.assertEqual(runtime_payload["revision_id"], "rev-123")
+        self.assertEqual(runtime_payload["actor"], "operator@example.com")
+        self.assertEqual(runtime_payload["notes"], "rotate policy bundle")
+        self.assertEqual(
+            runtime_payload["workflows"],
+            [{"workflow_id": "wf-1", "task_type": "analysis"}],
+        )
+
+        self.assertEqual(bundle_status, 200)
+        self.assertEqual(bundle_headers["Content-Type"], "application/gzip")
+        with tarfile.open(fileobj=io.BytesIO(bundle_body), mode="r:gz") as tar:
+            bundle_data = json.loads(tar.extractfile("data.json").read().decode("utf-8"))
+        self.assertEqual(bundle_data["policy_registry"]["workflows"], runtime_payload["workflows"])
+        self.assertEqual(bundle_data["bundle_meta"]["revision_id"], "rev-123")
+        self.assertEqual(bundle_data["bundle_meta"]["actor"], "operator@example.com")
+        self.assertEqual(bundle_data["bundle_meta"]["published_at"], runtime_payload["published_at"])
+        self.assertIn("generated_at", bundle_data["bundle_meta"])
+
+        log_lines = []
+        for line in captured_logs.output:
+            _, _, message = line.partition(":")
+            _, _, payload_text = message.partition(":")
+            log_lines.append(json.loads(payload_text))
+        publish_logs = [line for line in log_lines if line.get("event") == "policy_publish"]
+        self.assertTrue(publish_logs)
+        self.assertEqual(publish_logs[-1]["status"], 200)
+        self.assertEqual(publish_logs[-1]["actor"], "operator@example.com")
+
+    def test_policy_ui_publish_requires_api_key_before_proxying_upstream(self):
+        original_proxy = policy_bundle_server._proxy_n8n_json
+        self.addCleanup(setattr, policy_bundle_server, "_proxy_n8n_json", original_proxy)
+        policy_bundle_server.PUBLISH_API_KEY = "publish-secret"
+
+        def _unexpected_proxy(*args, **kwargs):
+            raise AssertionError("publish proxy should not be called without auth")
+
+        policy_bundle_server._proxy_n8n_json = _unexpected_proxy
+
+        server, thread = _start_server()
+        self.addCleanup(server.shutdown)
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join, 2)
+
+        status, payload = _post_json(
+            server.server_port,
+            "/policy-ui/api/publish",
+            {"revision_id": "rev-123", "actor": "policy-ui"},
+        )
+
+        self.assertEqual(status, 401)
+        self.assertEqual(payload["ok"], False)
+        self.assertEqual(payload["error"], "Unauthorized")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require `X-API-Key` auth for policy bundle publish endpoints backed by `POLICY_BUNDLE_PUBLISH_API_KEY`
- restore structured `policy_publish` audit logging for rejected and successful publish attempts
- keep OPA bundle reads compatible while updating the policy UI and operator docs for the new publish contract

## Root cause
The direct runtime publish handler accepted unauthenticated writes to the active policy registry, and publish attempts were not emitting a usable audit trail.

## What changed
- added publish-only auth enforcement and structured publish logging in `docker/policy-bundle-server/server.py`
- updated the policy UI publish flow to collect and forward the publish API key only for `POST /policy-ui/api/publish`
- documented `POLICY_BUNDLE_PUBLISH_API_KEY` in `.env.example`, `README.md`, and `docs/policy-registry-operations.md`
- added focused live-handler tests for unauthenticated rejection, authenticated publish success/logging, and UI proxy auth behavior

## Validation
- `python3 -m unittest -v tests.test_policy_bundle_server`
- `python3 -m py_compile docker/policy-bundle-server/server.py`
- `bash scripts/ci/build.sh`

Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing policy bundles now requires an API key (POLICY_BUNDLE_PUBLISH_API_KEY) and UI publish includes a required API-key input with validation.
  * Publish requests send the API key in an X-API-Key header.

* **Behavior Changes / Bug Fixes**
  * Publish endpoints now return clear Unauthorized/Service Unavailable responses when auth is missing or invalid.

* **Documentation**
  * Configuration and publishing guides updated to document the new auth requirement.

* **Tests**
  * Automated tests added to verify publish authentication and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->