### PR TITLE
Enforce branch protection and required checks on main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 Direct pushes to `main` are not allowed.
 
-Protected-branch policy verification:
+## Protected-branch policy verification
 
 ```bash
 bash scripts/ci/branch_protection_check.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,12 @@
 
 Direct pushes to `main` are not allowed.
 
+Protected-branch policy verification:
+
+```bash
+bash scripts/ci/branch_protection_check.sh
+```
+
 ## Required verification before merge
 
 ```bash

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -6,6 +6,7 @@ Owner: <team-or-role>
 ## 1) Technical Gates
 
 - [ ] CI required checks green (`Quality Gates / quality-gates`, `Validate workflows / validate`, `Validate workflows / import-test`, `Policy Tests / policy-and-executor`, `Security Audit / security-audit`)
+- [ ] `main` branch protection enforces pull requests, at least one approval, and the documented required checks (`bash scripts/ci/branch_protection_check.sh`)
 - [ ] End-to-end suite passes (`pnpm e2e`, includes import test + compose core journey)
 - [ ] Kubernetes smoke validation completed (`scripts/ci/k8s_smoke_test.sh`)
 - [ ] Release workflow available for SemVer tags (`.github/workflows/release.yml`)

--- a/scripts/ci/branch_protection_check.sh
+++ b/scripts/ci/branch_protection_check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-TommyKammy/nexus-ai-orchestrator}"
+branch="${GITHUB_BRANCH:-main}"
+
+required_contexts=(
+  "Quality Gates / quality-gates"
+  "Validate workflows / validate"
+  "Validate workflows / import-test"
+  "Policy Tests / policy-and-executor"
+  "Security Audit / security-audit"
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+protection_json="$(gh api "repos/${repo}/branches/${branch}/protection")"
+
+required_status_json="$(
+  gh api "repos/${repo}/branches/${branch}/protection/required_status_checks" 2>/dev/null || true
+)"
+
+expected_contexts_json="$(printf '%s\n' "${required_contexts[@]}" | python3 -c 'import json, sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))')"
+
+python3 - "$protection_json" "$required_status_json" "$expected_contexts_json" <<'PY'
+import json
+import sys
+
+protection = json.loads(sys.argv[1])
+required_status = json.loads(sys.argv[2]) if sys.argv[2] else None
+expected_contexts = json.loads(sys.argv[3])
+
+errors = []
+
+reviews = protection.get("required_pull_request_reviews") or {}
+if reviews.get("required_approving_review_count", 0) < 1:
+    errors.append("required_approving_review_count must be at least 1")
+
+if not protection.get("enforce_admins", {}).get("enabled", False):
+    errors.append("enforce_admins must be enabled")
+
+if protection.get("allow_force_pushes", {}).get("enabled", True):
+    errors.append("force pushes must be disabled")
+
+if protection.get("allow_deletions", {}).get("enabled", True):
+    errors.append("branch deletions must be disabled")
+
+if not protection.get("required_conversation_resolution", {}).get("enabled", False):
+    errors.append("required conversation resolution must be enabled")
+
+if not required_status:
+    errors.append("required status checks are not enabled")
+else:
+    if not required_status.get("strict", False):
+        errors.append("required status checks must require branches to be up to date")
+
+    actual_contexts = sorted(required_status.get("contexts") or [])
+    missing_contexts = [context for context in expected_contexts if context not in actual_contexts]
+    extra_contexts = [context for context in actual_contexts if context not in expected_contexts]
+
+    if missing_contexts:
+        errors.append(f"missing required status checks: {', '.join(missing_contexts)}")
+    if extra_contexts:
+        errors.append(f"unexpected required status checks: {', '.join(extra_contexts)}")
+
+if errors:
+    print("Branch protection policy check failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("Branch protection policy matches the documented main-branch requirements.")
+PY

--- a/scripts/ci/branch_protection_check.sh
+++ b/scripts/ci/branch_protection_check.sh
@@ -28,21 +28,27 @@ if ! protection_json="$(gh api "repos/${repo}/branches/${branch}/protection" 2>/
   exit 1
 fi
 
-required_status_json="$(
-  gh api "repos/${repo}/branches/${branch}/protection/required_status_checks" 2>/dev/null || true
-)"
+required_status_read_failed=0
+if ! required_status_json="$(
+  gh api "repos/${repo}/branches/${branch}/protection/required_status_checks" 2>/dev/null
+)"; then
+  required_status_json=""
+  required_status_read_failed=1
+fi
 
 expected_contexts_json="$(printf '%s\n' "${required_contexts[@]}" | python3 -c 'import json, sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))')"
 
-python3 - "$protection_json" "$required_status_json" "$expected_contexts_json" <<'PY'
+python3 - "$protection_json" "$required_status_json" "$expected_contexts_json" "$required_status_read_failed" <<'PY'
 import json
 import sys
 
 protection = json.loads(sys.argv[1])
 required_status = json.loads(sys.argv[2]) if sys.argv[2] else None
 expected_contexts = json.loads(sys.argv[3])
+required_status_read_failed = sys.argv[4] == "1"
 
 errors = []
+warnings = []
 
 reviews = protection.get("required_pull_request_reviews") or {}
 if reviews.get("required_approving_review_count", 0) < 1:
@@ -60,7 +66,9 @@ if protection.get("allow_deletions", {}).get("enabled", True):
 if not protection.get("required_conversation_resolution", {}).get("enabled", False):
     errors.append("required conversation resolution must be enabled")
 
-if not required_status:
+if required_status_read_failed:
+    errors.append("unable to read required status checks (verify gh auth/token scopes)")
+elif not required_status:
     errors.append("required status checks are not enabled")
 else:
     if not required_status.get("strict", False):
@@ -73,13 +81,16 @@ else:
     if missing_contexts:
         errors.append(f"missing required status checks: {', '.join(missing_contexts)}")
     if extra_contexts:
-        errors.append(f"unexpected required status checks: {', '.join(extra_contexts)}")
+        warnings.append(f"additional required status checks present: {', '.join(extra_contexts)}")
 
 if errors:
     print("Branch protection policy check failed:", file=sys.stderr)
     for error in errors:
         print(f"- {error}", file=sys.stderr)
     sys.exit(1)
+
+for warning in warnings:
+    print(f"Branch protection policy check warning: {warning}", file=sys.stderr)
 
 print("Branch protection policy matches the documented main-branch requirements.")
 PY

--- a/scripts/ci/branch_protection_check.sh
+++ b/scripts/ci/branch_protection_check.sh
@@ -22,7 +22,11 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-protection_json="$(gh api "repos/${repo}/branches/${branch}/protection")"
+if ! protection_json="$(gh api "repos/${repo}/branches/${branch}/protection" 2>/dev/null)"; then
+  echo "Branch protection policy check failed:" >&2
+  echo "- unable to read branch protection for ${repo}:${branch} (verify branch exists and gh auth/token scopes)" >&2
+  exit 1
+fi
 
 required_status_json="$(
   gh api "repos/${repo}/branches/${branch}/protection/required_status_checks" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add a focused `scripts/ci/branch_protection_check.sh` reproducer/verification for main-branch governance
- document the protected-branch verification in contributor and readiness docs
- apply the matching GitHub branch-protection policy on `main` with required checks and one approval

## Verification
- bash scripts/ci/branch_protection_check.sh
- gh api repos/TommyKammy/nexus-ai-orchestrator/branches/main/protection

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidance to verify branch protection before merging.
  * Added production-readiness checklist item requiring main branch protection to enforce PRs, require approvals, and include required checks.

* **Chores**
  * Added automated branch-protection validation tooling to verify approval requirements, status-check enforcement, and disallow force-pushes/deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->