### PR TITLE
Codify branch protection required check names

### DIFF
--- a/.codex-supervisor/issues/103/issue-journal.md
+++ b/.codex-supervisor/issues/103/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #103: Codify and verify branch protection required check names
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/103
+- Branch: codex/issue-103
+- Workspace: .
+- Journal: .codex-supervisor/issues/103/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 5ebf4729ed4c5850efad2f1244ab0f0267cfb8bd
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T01:01:02.551Z
+
+## Latest Codex Summary
+- Added a repo-local canonical manifest for `main` branch protection required checks, a validation script/wrapper, focused unittest coverage, and operator docs/runbook updates so stale `Workflow / job` names fail locally before merge is blocked.
+
+## Active Failure Context
+- Reproduced initial drift with `bash scripts/ci/branch_protection_check_names_check.sh`, which failed on stale checklist references like `Quality Gates / quality-gates` instead of the exact reported check names.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: PR merge blocking came from branch protection expecting exact short check names while repo docs still advertised stale `Workflow / job` display strings and there was no local drift detector.
+- What changed: Added `scripts/ci/branch_protection_required_checks.json`, `scripts/check_branch_protection_check_names.py`, `scripts/ci/branch_protection_check_names_check.sh`, `tests/test_branch_protection_check_names.py`, updated `docs/production-readiness-checklist.md`, `docs/release-process.md`, `README.md`, and added `docs/branch-protection-checks-runbook.md`.
+- Current blocker: none
+- Next exact step: Commit the checkpoint on `codex/issue-103`; PR opening can happen after commit if needed.
+- Verification gap: No GitHub-side branch protection inspection was performed locally; verification is repo-local drift detection plus existing workflow/build checks.
+- Files touched: README.md; docs/production-readiness-checklist.md; docs/release-process.md; docs/branch-protection-checks-runbook.md; scripts/check_branch_protection_check_names.py; scripts/ci/branch_protection_check_names_check.sh; scripts/ci/branch_protection_required_checks.json; tests/test_branch_protection_check_names.py; .codex-supervisor/issues/103/issue-journal.md
+- Rollback concern: Low; changes are additive except doc wording updates, and the new validation only reads repo files.
+- Last focused command: bash scripts/ci/build.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/103/issue-journal.md
+++ b/.codex-supervisor/issues/103/issue-journal.md
@@ -6,41 +6,38 @@
 - Workspace: .
 - Journal: .codex-supervisor/issues/103/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 3 (implementation=2, repair=1)
-- Last head SHA: 02918b08c9556ba2d0ba16fd65e4baa2d6c05e21
+- Attempt count: 4 (implementation=2, repair=2)
+- Last head SHA: 072c31c885a8153ef9045988f8af249d6f20b6eb
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORd-8zc56Q9tw|PRRT_kwDORd-8zc56Q9tz|PRRT_kwDORd-8zc56Q9t0|PRRT_kwDORd-8zc56Q9t4
+- Last failure signature: PRRT_kwDORd-8zc56RD68
 - Repeated failure signature count: 1
-- Updated at: 2026-04-11T01:19:58.235Z
+- Updated at: 2026-04-11T01:30:25.977Z
 
 ## Latest Codex Summary
-Draft PR #105 is open: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105
+Updated [scripts/check_branch_protection_check_names.py](scripts/check_branch_protection_check_names.py) and [tests/test_branch_protection_check_names.py](tests/test_branch_protection_check_names.py) to address the remaining unresolved CodeRabbit thread on stale doc detection. The validator now flags any legacy `workflow-like label / <required-check>` reference in docs instead of only aliases derived from the current workflow name, and `legacy_doc_aliases_for_required_checks` now iterates every producer path for a required check rather than only the first one.
 
-Addressed the four unresolved automated review comments on PR #105 locally. The validator now checks the new runbook by default, handles inline comments and non-two-space workflow indentation without misreading nested step metadata as job names, uses `rsplit(":", 1)` for Windows-style producer paths, and the unit tests now clean up their temp fixture directories while covering the new parser edge cases.
+The new regression coverage proves the rename case that motivated the review: docs containing an old alias like `Old Validate Pipeline / validate` now fail even when the current workflow is still named `Validate workflows`. Local verification passed with `python3 -m unittest -v tests.test_branch_protection_check_names`, `bash scripts/ci/branch_protection_check_names_check.sh`, `bash scripts/ci/workflow_schema_check.sh`, and `bash scripts/ci/build.sh`; `build.sh` still emits the existing docker-compose warnings about unset API key env vars and the obsolete compose `version` field, but it did not fail.
 
-Summary: Fixed PR #105 review feedback in the branch-protection validator and expanded regression coverage
+Summary: Tightened legacy doc alias detection for renamed workflows and added regression coverage for the remaining PR #105 review thread
 State hint: addressing_review
 Blocked reason: none
-Tests: python3 -m unittest -v tests.test_branch_protection_check_names; bash scripts/ci/branch_protection_check_names_check.sh; bash scripts/ci/workflow_schema_check.sh; bash scripts/ci/build.sh
-Next action: Commit and push the review-fix checkpoint to update PR #105, then monitor CI/review state
-Failure signature: none
+Tests: `gh pr view 105 --repo TommyKammy/nexus-ai-orchestrator --json number,url,isDraft,headRefName,headRefOid,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup`; `python3 /Users/jp.infra/.codex/plugins/cache/openai-curated/github/fb0a18376bcd9f2604047fbe7459ec5aed70c64b/skills/gh-address-comments/scripts/fetch_comments.py --repo TommyKammy/nexus-ai-orchestrator --pr 105`; `python3 -m unittest -v tests.test_branch_protection_check_names`; `bash scripts/ci/branch_protection_check_names_check.sh`; `bash scripts/ci/workflow_schema_check.sh`; `bash scripts/ci/build.sh`
+Next action: Commit and push the local review fix on `codex/issue-103`, then re-check PR #105 review-thread and merge state
+Failure signature: PRRT_kwDORd-8zc56RD68
 
 ## Active Failure Context
 - Category: review
-- Summary: 4 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304197
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067334489
 - Details:
-  - scripts/check_branch_protection_check_names.py:23 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Validate the new runbook by default too.** Lines 20-23 omit `docs/branch-protection-checks-runbook.md`, so the validator will not catch stale... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304197
-  - scripts/check_branch_protection_check_names.py:25 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/nexus-ai-orchestrator Length of output: 6206 --- 🏁 Script executed: Repository: T... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304200
-  - scripts/check_branch_protection_check_names.py:121 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Don’t recover the workflow path with `split(":", 1)`.** Line 117 breaks on Windows absolute paths such as `<redacted-local-path>.`, because the first colon i... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304202
-  - tests/test_branch_protection_check_names.py:25 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Clean up temporary fixture directories after each test.** Line 19 creates temp directories but they are never removed, which can accumulate a... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304205
+  - scripts/check_branch_protection_check_names.py:191 summary=_⚠️ Potential issue_ | _🟠 Major_ **Don’t key stale-doc detection to the current workflow name only.** Right now the validator only searches docs for exact aliases built from th... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067334489
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: PR merge blocking came from branch protection expecting exact short check names while repo docs still advertised stale `Workflow / job` display strings and there was no local drift detector.
-- What changed: Added the runbook to `DEFAULT_DOCS`, hardened `scripts/check_branch_protection_check_names.py` so it correctly parses inline comments and flexible indentation without mistaking nested step metadata for job names, switched producer path splitting to `rsplit(":", 1)`, and expanded `tests/test_branch_protection_check_names.py` to cover those review cases and clean up temp fixture repos.
+- What changed: Kept the earlier parser hardening and additionally changed stale-doc detection so it matches any legacy `label / <required-check>` form in docs, not just aliases built from the current workflow name. `legacy_doc_aliases_for_required_checks` now walks every producer path for a required check, and the tests cover both a renamed-workflow alias in docs and multi-producer alias collection.
 - Current blocker: none
-- Next exact step: Commit and push the local validator/test fixes to `codex/issue-103`, then check PR #105 CI and remaining review-thread state.
+- Next exact step: Commit and push the current review fix on `codex/issue-103`, then re-check PR #105 review-thread state and merge status.
 - Verification gap: No GitHub-side branch protection inspection was performed locally; verification remains repo-local drift detection plus existing workflow/build checks and pending PR CI.
 - Files touched: README.md; docs/production-readiness-checklist.md; docs/release-process.md; docs/branch-protection-checks-runbook.md; scripts/check_branch_protection_check_names.py; scripts/ci/branch_protection_check_names_check.sh; scripts/ci/branch_protection_required_checks.json; tests/test_branch_protection_check_names.py; .codex-supervisor/issues/103/issue-journal.md
 - Rollback concern: Low; changes are additive except doc wording updates, and the new validation only reads repo files.
@@ -48,3 +45,4 @@ Failure signature: none
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
 - `bash scripts/ci/branch_protection_check_names_check.sh` initially failed because the parser treated nested `with.name` values as job names; direct job-property indentation tracking fixed that false negative.
+- Live GitHub thread fetch still shows `PRRT_kwDORd-8zc56RD68` unresolved; the current file still had the rename gap, so the latest fix moved doc detection to a generic `label / required-check` match instead of current-workflow-only aliases.

--- a/.codex-supervisor/issues/103/issue-journal.md
+++ b/.codex-supervisor/issues/103/issue-journal.md
@@ -5,29 +5,46 @@
 - Branch: codex/issue-103
 - Workspace: .
 - Journal: .codex-supervisor/issues/103/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: 5ebf4729ed4c5850efad2f1244ab0f0267cfb8bd
+- Current phase: addressing_review
+- Attempt count: 3 (implementation=2, repair=1)
+- Last head SHA: 02918b08c9556ba2d0ba16fd65e4baa2d6c05e21
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T01:01:02.551Z
+- Last failure signature: PRRT_kwDORd-8zc56Q9tw|PRRT_kwDORd-8zc56Q9tz|PRRT_kwDORd-8zc56Q9t0|PRRT_kwDORd-8zc56Q9t4
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T01:19:58.235Z
 
 ## Latest Codex Summary
-- Added a repo-local canonical manifest for `main` branch protection required checks, a validation script/wrapper, focused unittest coverage, and operator docs/runbook updates so stale `Workflow / job` names fail locally before merge is blocked.
+Draft PR #105 is open: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105
+
+Addressed the four unresolved automated review comments on PR #105 locally. The validator now checks the new runbook by default, handles inline comments and non-two-space workflow indentation without misreading nested step metadata as job names, uses `rsplit(":", 1)` for Windows-style producer paths, and the unit tests now clean up their temp fixture directories while covering the new parser edge cases.
+
+Summary: Fixed PR #105 review feedback in the branch-protection validator and expanded regression coverage
+State hint: addressing_review
+Blocked reason: none
+Tests: python3 -m unittest -v tests.test_branch_protection_check_names; bash scripts/ci/branch_protection_check_names_check.sh; bash scripts/ci/workflow_schema_check.sh; bash scripts/ci/build.sh
+Next action: Commit and push the review-fix checkpoint to update PR #105, then monitor CI/review state
+Failure signature: none
 
 ## Active Failure Context
-- Reproduced initial drift with `bash scripts/ci/branch_protection_check_names_check.sh`, which failed on stale checklist references like `Quality Gates / quality-gates` instead of the exact reported check names.
+- Category: review
+- Summary: 4 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304197
+- Details:
+  - scripts/check_branch_protection_check_names.py:23 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Validate the new runbook by default too.** Lines 20-23 omit `docs/branch-protection-checks-runbook.md`, so the validator will not catch stale... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304197
+  - scripts/check_branch_protection_check_names.py:25 summary=_⚠️ Potential issue_ | _🟠 Major_ 🧩 Analysis chain 🏁 Script executed: Repository: TommyKammy/nexus-ai-orchestrator Length of output: 6206 --- 🏁 Script executed: Repository: T... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304200
+  - scripts/check_branch_protection_check_names.py:121 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Don’t recover the workflow path with `split(":", 1)`.** Line 117 breaks on Windows absolute paths such as `<redacted-local-path>.`, because the first colon i... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304202
+  - tests/test_branch_protection_check_names.py:25 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Clean up temporary fixture directories after each test.** Line 19 creates temp directories but they are never removed, which can accumulate a... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/105#discussion_r3067304205
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: PR merge blocking came from branch protection expecting exact short check names while repo docs still advertised stale `Workflow / job` display strings and there was no local drift detector.
-- What changed: Added `scripts/ci/branch_protection_required_checks.json`, `scripts/check_branch_protection_check_names.py`, `scripts/ci/branch_protection_check_names_check.sh`, `tests/test_branch_protection_check_names.py`, updated `docs/production-readiness-checklist.md`, `docs/release-process.md`, `README.md`, and added `docs/branch-protection-checks-runbook.md`.
+- What changed: Added the runbook to `DEFAULT_DOCS`, hardened `scripts/check_branch_protection_check_names.py` so it correctly parses inline comments and flexible indentation without mistaking nested step metadata for job names, switched producer path splitting to `rsplit(":", 1)`, and expanded `tests/test_branch_protection_check_names.py` to cover those review cases and clean up temp fixture repos.
 - Current blocker: none
-- Next exact step: Commit the checkpoint on `codex/issue-103`; PR opening can happen after commit if needed.
-- Verification gap: No GitHub-side branch protection inspection was performed locally; verification is repo-local drift detection plus existing workflow/build checks.
+- Next exact step: Commit and push the local validator/test fixes to `codex/issue-103`, then check PR #105 CI and remaining review-thread state.
+- Verification gap: No GitHub-side branch protection inspection was performed locally; verification remains repo-local drift detection plus existing workflow/build checks and pending PR CI.
 - Files touched: README.md; docs/production-readiness-checklist.md; docs/release-process.md; docs/branch-protection-checks-runbook.md; scripts/check_branch_protection_check_names.py; scripts/ci/branch_protection_check_names_check.sh; scripts/ci/branch_protection_required_checks.json; tests/test_branch_protection_check_names.py; .codex-supervisor/issues/103/issue-journal.md
 - Rollback concern: Low; changes are additive except doc wording updates, and the new validation only reads repo files.
 - Last focused command: bash scripts/ci/build.sh
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.
+- `bash scripts/ci/branch_protection_check_names_check.sh` initially failed because the parser treated nested `with.name` values as job names; direct job-property indentation tracking fixed that false negative.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ pnpm e2e:compose-core
 
 # full regression entrypoint
 bash scripts/ci/regression.sh
+
+# branch protection required check drift detection
+bash scripts/ci/branch_protection_check_names_check.sh
 ```
 
 ## Kubernetes Path
@@ -123,6 +126,7 @@ K8s CI/load checks:
 - Threat model: `docs/security-threat-model-v1.md`
 - Security audit report: `docs/reports/security-audit-report-20260305.md`
 - Rollback/DR runbook: `docs/rollback-dr-runbook.md`
+- Branch protection required checks runbook: `docs/branch-protection-checks-runbook.md`
 - DR drill evidence: `docs/reports/dr-drill-20260305.md`
 - Production readiness checklist: `docs/production-readiness-checklist.md`
 - Production sign-off record: `docs/reports/production-readiness-signoff-20260305.md`

--- a/docs/branch-protection-checks-runbook.md
+++ b/docs/branch-protection-checks-runbook.md
@@ -1,0 +1,43 @@
+# Branch Protection Required Checks Runbook
+
+This repository treats the exact GitHub-reported check names for `main` as a
+repo-local contract. The canonical source is
+`scripts/ci/branch_protection_required_checks.json`.
+
+## Canonical `main` Required Checks
+
+- `quality-gates`
+- `validate`
+- `import-test`
+- `policy-and-executor`
+- `security-audit`
+
+## Verification Command
+
+Run this before changing workflow job IDs, workflow job `name:` values, or
+GitHub branch protection settings:
+
+```bash
+bash scripts/ci/branch_protection_check_names_check.sh
+```
+
+The command fails when:
+- a canonical required check is no longer produced by any workflow job under
+  `.github/workflows/`
+- an operator-facing doc still uses a stale `Workflow / job` display string
+  instead of the exact reported check name
+
+## Safe Update Sequence
+
+1. Rename the workflow job ID or job `name:` in `.github/workflows/*.yml`.
+2. Update `scripts/ci/branch_protection_required_checks.json` if the exact
+   reported check name changed.
+3. Update operator docs to use the exact reported check name, not
+   `Workflow / job`.
+4. Run `bash scripts/ci/branch_protection_check_names_check.sh`.
+5. Run the usual CI verification for the affected change set.
+6. After the branch is green, update GitHub `main` branch protection to match
+   the canonical list.
+
+Do not guess required check names from stale docs or historical GitHub UI
+screenshots. Use the manifest and validation command as the source of truth.

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -5,7 +5,7 @@ Owner: <team-or-role>
 
 ## 1) Technical Gates
 
-- [ ] CI required checks green (`Quality Gates / quality-gates`, `Validate workflows / validate`, `Validate workflows / import-test`, `Policy Tests / policy-and-executor`, `Security Audit / security-audit`)
+- [ ] CI required checks green (`quality-gates`, `validate`, `import-test`, `policy-and-executor`, `security-audit`)
 - [ ] End-to-end suite passes (`pnpm e2e`, includes import test + compose core journey)
 - [ ] Kubernetes smoke validation completed (`scripts/ci/k8s_smoke_test.sh`)
 - [ ] Release workflow available for SemVer tags (`.github/workflows/release.yml`)
@@ -17,6 +17,7 @@ Owner: <team-or-role>
 - [ ] Backup/restore procedure validated for n8n/postgres (`scripts/n8n-upgrade-backup.sh`, `scripts/n8n-rollback.sh`)
 - [ ] DR drill evidence recorded (`docs/reports/dr-drill-20260305.md`)
 - [ ] Release cut and rollback procedure documented (`docs/release-process.md`)
+- [ ] Branch protection required checks verified with `bash scripts/ci/branch_protection_check_names_check.sh`
 
 ## 3) Security Gates
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,7 +20,21 @@
 ## Standard Release Cut
 
 1. Ensure `main` is green.
-2. Create and push release tag:
+2. Verify branch protection required checks before tagging:
+
+```bash
+bash scripts/ci/branch_protection_check_names_check.sh
+```
+
+Canonical `main` required checks:
+- `quality-gates`
+- `validate`
+- `import-test`
+- `policy-and-executor`
+- `security-audit`
+
+Safe update procedure for workflow/job renames: `docs/branch-protection-checks-runbook.md`
+3. Create and push release tag:
 
 ```bash
 git checkout main
@@ -29,8 +43,8 @@ git tag -a v1.0.0 -m "v1.0.0"
 git push origin v1.0.0
 ```
 
-3. Confirm GitHub Actions `Release` workflow succeeded.
-4. Confirm GitHub Release page contains generated notes artifact/body.
+4. Confirm GitHub Actions `Release` workflow succeeded.
+5. Confirm GitHub Release page contains generated notes artifact/body.
 
 ## Dry-run Procedure
 

--- a/scripts/check_branch_protection_check_names.py
+++ b/scripts/check_branch_protection_check_names.py
@@ -177,18 +177,15 @@ def collect_workflow_checks(workflow_dir: Path) -> tuple[dict[str, list[str]], l
 def legacy_doc_aliases_for_required_checks(
     required_checks: list[str], produced_checks: dict[str, list[str]]
 ) -> list[str]:
-    aliases: list[str] = []
+    aliases: set[str] = set()
     for check_name in required_checks:
-        producers = produced_checks.get(check_name, [])
-        if not producers:
-            continue
-
-        producer_path = producers[0].rsplit(":", 1)[0]
-        workflow_path = Path(producer_path)
-        workflow_name = read_workflow_name(workflow_path)
-        if workflow_name:
-            aliases.append(f"{workflow_name} / {check_name}")
-    return aliases
+        for producer in produced_checks.get(check_name, []):
+            producer_path = producer.rsplit(":", 1)[0]
+            workflow_path = Path(producer_path)
+            workflow_name = read_workflow_name(workflow_path)
+            if workflow_name:
+                aliases.add(f"{workflow_name} / {check_name}")
+    return sorted(aliases)
 
 
 def read_workflow_name(workflow_path: Path) -> str | None:
@@ -210,17 +207,27 @@ def read_workflow_name(workflow_path: Path) -> str | None:
     return None
 
 
-def validate_docs(doc_paths: list[Path], legacy_aliases: list[str]) -> list[str]:
+def _legacy_doc_alias_pattern(required_checks: list[str]) -> re.Pattern[str]:
+    check_names = sorted((re.escape(check_name) for check_name in required_checks), key=len, reverse=True)
+    alternation = "|".join(check_names)
+    return re.compile(
+        rf"(?:^|[\s([{{'\"`])(?P<alias>[^`\n/][^`\n/]*? / (?P<check>{alternation}))"
+        rf"(?=$|[\s)\]}}.,;:!?'\"`])"
+    )
+
+
+def validate_docs(doc_paths: list[Path], required_checks: list[str]) -> list[str]:
     errors: list[str] = []
+    legacy_alias_pattern = _legacy_doc_alias_pattern(required_checks)
 
     for doc_path in doc_paths:
         content = doc_path.read_text(encoding="utf-8")
-        for alias in legacy_aliases:
-            if alias in content:
-                errors.append(
-                    f"{doc_path}: replace legacy workflow/job display name '{alias}' "
-                    "with the exact reported check name"
-                )
+        legacy_aliases = {match.group("alias") for match in legacy_alias_pattern.finditer(content)}
+        for alias in sorted(legacy_aliases):
+            errors.append(
+                f"{doc_path}: replace legacy workflow/job display name '{alias}' "
+                "with the exact reported check name"
+            )
 
     return errors
 
@@ -247,13 +254,12 @@ def validate_branch_protection_check_names(
                 f"required check '{check_name}' for branch '{branch}' is not produced by any workflow job"
             )
 
-    legacy_aliases = legacy_doc_aliases_for_required_checks(required_checks, produced_checks)
     for doc_path in doc_paths:
         if not doc_path.exists():
             errors.append(f"{doc_path}: doc file not found")
 
     existing_docs = [doc_path for doc_path in doc_paths if doc_path.exists()]
-    errors.extend(validate_docs(existing_docs, legacy_aliases))
+    errors.extend(validate_docs(existing_docs, required_checks))
     return errors
 
 

--- a/scripts/check_branch_protection_check_names.py
+++ b/scripts/check_branch_protection_check_names.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Validate canonical branch protection required check names.
+
+The canonical required checks live in a repo-local manifest so workflow and
+operator-doc drift is detected before GitHub branch protection blocks merges.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "scripts" / "ci" / "branch_protection_required_checks.json"
+DEFAULT_WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+DEFAULT_DOCS = [
+    REPO_ROOT / "docs" / "production-readiness-checklist.md",
+    REPO_ROOT / "docs" / "release-process.md",
+]
+JOB_KEY_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+JOB_NAME_RE = re.compile(r"^    name:\s*(.+?)\s*$")
+
+
+def load_required_checks(manifest_path: Path, branch: str) -> list[str]:
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    checks = data.get(branch)
+    if not isinstance(checks, list) or not checks:
+        raise ValueError(f"{manifest_path}: missing non-empty list for branch '{branch}'")
+
+    normalized: list[str] = []
+    for idx, check_name in enumerate(checks):
+        if not isinstance(check_name, str) or not check_name.strip():
+            raise ValueError(f"{manifest_path}: invalid check entry at index {idx}")
+        normalized.append(check_name.strip())
+
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"{manifest_path}: duplicate check names for branch '{branch}'")
+
+    return normalized
+
+
+def parse_workflow_jobs(workflow_path: Path) -> list[tuple[str, str]]:
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
+    jobs_started = False
+    current_job_id: str | None = None
+    current_job_name: str | None = None
+    parsed_jobs: list[tuple[str, str]] = []
+
+    for line in lines:
+        if not jobs_started:
+            if line == "jobs:":
+                jobs_started = True
+            continue
+
+        if line and not line.startswith(" "):
+            break
+
+        job_key_match = JOB_KEY_RE.match(line)
+        if job_key_match:
+            if current_job_id is not None:
+                parsed_jobs.append((current_job_id, current_job_name or current_job_id))
+            current_job_id = job_key_match.group(1)
+            current_job_name = None
+            continue
+
+        if current_job_id is None:
+            continue
+
+        job_name_match = JOB_NAME_RE.match(line)
+        if job_name_match and current_job_name is None:
+            current_job_name = job_name_match.group(1).strip().strip("\"'")
+
+    if current_job_id is not None:
+        parsed_jobs.append((current_job_id, current_job_name or current_job_id))
+
+    return parsed_jobs
+
+
+def collect_workflow_checks(workflow_dir: Path) -> tuple[dict[str, list[str]], list[str]]:
+    workflow_paths = sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
+    if not workflow_paths:
+        return {}, [f"{workflow_dir}: no workflow files found"]
+
+    produced_checks: dict[str, list[str]] = {}
+    errors: list[str] = []
+
+    for workflow_path in workflow_paths:
+        jobs = parse_workflow_jobs(workflow_path)
+        if not jobs:
+            errors.append(f"{workflow_path}: no jobs found")
+            continue
+
+        for job_id, check_name in jobs:
+            produced_checks.setdefault(check_name, []).append(f"{workflow_path}:{job_id}")
+
+    for check_name, producers in sorted(produced_checks.items()):
+        if len(producers) > 1:
+            joined = ", ".join(producers)
+            errors.append(f"duplicate produced check name '{check_name}' from {joined}")
+
+    return produced_checks, errors
+
+
+def legacy_doc_aliases_for_required_checks(
+    required_checks: list[str], produced_checks: dict[str, list[str]]
+) -> list[str]:
+    aliases: list[str] = []
+    for check_name in required_checks:
+        producers = produced_checks.get(check_name, [])
+        if not producers:
+            continue
+
+        producer_path = producers[0].split(":", 1)[0]
+        workflow_path = Path(producer_path)
+        workflow_name = read_workflow_name(workflow_path)
+        if workflow_name:
+            aliases.append(f"{workflow_name} / {check_name}")
+    return aliases
+
+
+def read_workflow_name(workflow_path: Path) -> str | None:
+    for line in workflow_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("name:"):
+            return line.split(":", 1)[1].strip().strip("\"'")
+    return None
+
+
+def validate_docs(doc_paths: list[Path], legacy_aliases: list[str]) -> list[str]:
+    errors: list[str] = []
+
+    for doc_path in doc_paths:
+        content = doc_path.read_text(encoding="utf-8")
+        for alias in legacy_aliases:
+            if alias in content:
+                errors.append(
+                    f"{doc_path}: replace legacy workflow/job display name '{alias}' "
+                    "with the exact reported check name"
+                )
+
+    return errors
+
+
+def validate_branch_protection_check_names(
+    manifest_path: Path,
+    workflow_dir: Path,
+    branch: str,
+    doc_paths: list[Path],
+) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        required_checks = load_required_checks(manifest_path, branch)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        return [str(exc)]
+
+    produced_checks, workflow_errors = collect_workflow_checks(workflow_dir)
+    errors.extend(workflow_errors)
+
+    for check_name in required_checks:
+        if check_name not in produced_checks:
+            errors.append(
+                f"required check '{check_name}' for branch '{branch}' is not produced by any workflow job"
+            )
+
+    legacy_aliases = legacy_doc_aliases_for_required_checks(required_checks, produced_checks)
+    for doc_path in doc_paths:
+        if not doc_path.exists():
+            errors.append(f"{doc_path}: doc file not found")
+
+    existing_docs = [doc_path for doc_path in doc_paths if doc_path.exists()]
+    errors.extend(validate_docs(existing_docs, legacy_aliases))
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Validate canonical branch protection required checks")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--workflow-dir", type=Path, default=DEFAULT_WORKFLOW_DIR)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("docs", nargs="*", type=Path, default=DEFAULT_DOCS)
+    args = parser.parse_args(argv)
+
+    errors = validate_branch_protection_check_names(
+        manifest_path=args.manifest,
+        workflow_dir=args.workflow_dir,
+        branch=args.branch,
+        doc_paths=args.docs,
+    )
+    if errors:
+        print("Branch protection check name validation FAILED")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"Branch protection check name validation passed for '{args.branch}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_branch_protection_check_names.py
+++ b/scripts/check_branch_protection_check_names.py
@@ -19,10 +19,10 @@ DEFAULT_MANIFEST = REPO_ROOT / "scripts" / "ci" / "branch_protection_required_ch
 DEFAULT_WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 DEFAULT_DOCS = [
     REPO_ROOT / "docs" / "production-readiness-checklist.md",
+    REPO_ROOT / "docs" / "branch-protection-checks-runbook.md",
     REPO_ROOT / "docs" / "release-process.md",
 ]
-JOB_KEY_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
-JOB_NAME_RE = re.compile(r"^    name:\s*(.+?)\s*$")
+JOB_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def load_required_checks(manifest_path: Path, branch: str) -> list[str]:
@@ -43,36 +43,105 @@ def load_required_checks(manifest_path: Path, branch: str) -> list[str]:
     return normalized
 
 
+def _leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _strip_inline_comment(line: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    stripped: list[str] = []
+
+    for idx, char in enumerate(line):
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif char == "#" and not in_single_quote and not in_double_quote:
+            previous = line[idx - 1] if idx > 0 else ""
+            if idx == 0 or previous.isspace():
+                break
+        stripped.append(char)
+
+    return "".join(stripped).rstrip()
+
+
+def _parse_mapping_entry(line: str) -> tuple[str, str] | None:
+    if ":" not in line:
+        return None
+
+    key, value = line.split(":", 1)
+    key = key.strip()
+    if not key:
+        return None
+
+    return key, value.strip()
+
+
+def _normalize_scalar(value: str) -> str:
+    normalized = value.strip()
+    if len(normalized) >= 2 and normalized[0] == normalized[-1] and normalized[0] in {"'", '"'}:
+        return normalized[1:-1].strip()
+    return normalized
+
+
 def parse_workflow_jobs(workflow_path: Path) -> list[tuple[str, str]]:
     lines = workflow_path.read_text(encoding="utf-8").splitlines()
-    jobs_started = False
+    jobs_indent: int | None = None
+    job_indent: int | None = None
+    current_property_indent: int | None = None
     current_job_id: str | None = None
     current_job_name: str | None = None
     parsed_jobs: list[tuple[str, str]] = []
 
-    for line in lines:
-        if not jobs_started:
-            if line == "jobs:":
-                jobs_started = True
+    for raw_line in lines:
+        line = _strip_inline_comment(raw_line)
+        if not line.strip():
             continue
 
-        if line and not line.startswith(" "):
-            break
+        indent = _leading_spaces(line)
+        content = line[indent:]
 
-        job_key_match = JOB_KEY_RE.match(line)
-        if job_key_match:
+        if jobs_indent is None:
+            if indent == 0 and content == "jobs:":
+                jobs_indent = indent
+            continue
+
+        if indent <= jobs_indent:
             if current_job_id is not None:
                 parsed_jobs.append((current_job_id, current_job_name or current_job_id))
-            current_job_id = job_key_match.group(1)
-            current_job_name = None
+            break
+
+        if content.endswith(":"):
+            candidate_job_id = content[:-1].strip()
+            if JOB_KEY_RE.fullmatch(candidate_job_id) and (job_indent is None or indent == job_indent):
+                if current_job_id is not None:
+                    parsed_jobs.append((current_job_id, current_job_name or current_job_id))
+                current_job_id = candidate_job_id
+                current_job_name = None
+                current_property_indent = None
+                job_indent = indent
+                continue
+
+        if current_job_id is None or job_indent is None or indent <= job_indent:
             continue
 
-        if current_job_id is None:
+        if content.startswith("-"):
             continue
 
-        job_name_match = JOB_NAME_RE.match(line)
-        if job_name_match and current_job_name is None:
-            current_job_name = job_name_match.group(1).strip().strip("\"'")
+        if current_property_indent is None:
+            current_property_indent = indent
+
+        if indent != current_property_indent:
+            continue
+
+        parsed_entry = _parse_mapping_entry(content)
+        if parsed_entry is None:
+            continue
+
+        key, value = parsed_entry
+        if key == "name" and current_job_name is None:
+            current_job_name = _normalize_scalar(value)
 
     if current_job_id is not None:
         parsed_jobs.append((current_job_id, current_job_name or current_job_id))
@@ -114,7 +183,7 @@ def legacy_doc_aliases_for_required_checks(
         if not producers:
             continue
 
-        producer_path = producers[0].split(":", 1)[0]
+        producer_path = producers[0].rsplit(":", 1)[0]
         workflow_path = Path(producer_path)
         workflow_name = read_workflow_name(workflow_path)
         if workflow_name:
@@ -123,9 +192,21 @@ def legacy_doc_aliases_for_required_checks(
 
 
 def read_workflow_name(workflow_path: Path) -> str | None:
-    for line in workflow_path.read_text(encoding="utf-8").splitlines():
-        if line.startswith("name:"):
-            return line.split(":", 1)[1].strip().strip("\"'")
+    for raw_line in workflow_path.read_text(encoding="utf-8").splitlines():
+        line = _strip_inline_comment(raw_line)
+        if not line.strip():
+            continue
+
+        if _leading_spaces(line) != 0:
+            continue
+
+        parsed_entry = _parse_mapping_entry(line)
+        if parsed_entry is None:
+            continue
+
+        key, value = parsed_entry
+        if key == "name":
+            return _normalize_scalar(value)
     return None
 
 

--- a/scripts/ci/branch_protection_check_names_check.sh
+++ b/scripts/ci/branch_protection_check_names_check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 scripts/check_branch_protection_check_names.py

--- a/scripts/ci/branch_protection_required_checks.json
+++ b/scripts/ci/branch_protection_required_checks.json
@@ -1,0 +1,9 @@
+{
+  "main": [
+    "quality-gates",
+    "validate",
+    "import-test",
+    "policy-and-executor",
+    "security-audit"
+  ]
+}

--- a/tests/test_branch_protection_check_names.py
+++ b/tests/test_branch_protection_check_names.py
@@ -1,0 +1,110 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_branch_protection_check_names.py"
+)
+SPEC = importlib.util.spec_from_file_location("branch_protection_check_names", MODULE_PATH)
+branch_protection_check_names = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(branch_protection_check_names)
+
+
+class BranchProtectionCheckNamesTests(unittest.TestCase):
+    def _write_fixture_repo(self) -> tuple[Path, Path, Path, list[Path]]:
+        tmpdir = Path(tempfile.mkdtemp(prefix="branch-protection-checks-"))
+        manifest_path = tmpdir / "branch_protection_required_checks.json"
+        workflow_dir = tmpdir / "workflows"
+        workflow_dir.mkdir()
+        docs_dir = tmpdir / "docs"
+        docs_dir.mkdir()
+        doc_paths = [docs_dir / "checklist.md", docs_dir / "release.md"]
+
+        manifest_path.write_text(
+            json.dumps({"main": ["quality-gates", "validate", "import-test"]}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (workflow_dir / "quality-gates.yml").write_text(
+            "\n".join(
+                [
+                    "name: Quality Gates",
+                    "",
+                    "jobs:",
+                    "  quality-gates:",
+                    "    runs-on: ubuntu-latest",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (workflow_dir / "validate-workflows.yml").write_text(
+            "\n".join(
+                [
+                    "name: Validate workflows",
+                    "",
+                    "jobs:",
+                    "  validate:",
+                    "    runs-on: ubuntu-latest",
+                    "  import-test:",
+                    "    runs-on: ubuntu-latest",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        for doc_path in doc_paths:
+            doc_path.write_text("Checks: `quality-gates`, `validate`, `import-test`\n", encoding="utf-8")
+
+        return tmpdir, manifest_path, workflow_dir, doc_paths
+
+    def test_validation_passes_for_matching_manifest_and_short_check_names(self):
+        _, manifest_path, workflow_dir, doc_paths = self._write_fixture_repo()
+
+        errors = branch_protection_check_names.validate_branch_protection_check_names(
+            manifest_path=manifest_path,
+            workflow_dir=workflow_dir,
+            branch="main",
+            doc_paths=doc_paths,
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_validation_fails_when_required_check_is_missing(self):
+        _, manifest_path, workflow_dir, doc_paths = self._write_fixture_repo()
+        manifest_path.write_text(
+            json.dumps({"main": ["quality-gates", "validate", "missing-check"]}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        errors = branch_protection_check_names.validate_branch_protection_check_names(
+            manifest_path=manifest_path,
+            workflow_dir=workflow_dir,
+            branch="main",
+            doc_paths=doc_paths,
+        )
+
+        self.assertTrue(any("missing-check" in error for error in errors))
+
+    def test_validation_fails_for_legacy_workflow_job_display_names_in_docs(self):
+        _, manifest_path, workflow_dir, doc_paths = self._write_fixture_repo()
+        doc_paths[0].write_text(
+            "Checks: `Quality Gates / quality-gates`, `validate`, `import-test`\n",
+            encoding="utf-8",
+        )
+
+        errors = branch_protection_check_names.validate_branch_protection_check_names(
+            manifest_path=manifest_path,
+            workflow_dir=workflow_dir,
+            branch="main",
+            doc_paths=doc_paths,
+        )
+
+        self.assertTrue(any("Quality Gates / quality-gates" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_branch_protection_check_names.py
+++ b/tests/test_branch_protection_check_names.py
@@ -1,7 +1,9 @@
 import importlib.util
 import json
+import shutil
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -17,6 +19,7 @@ SPEC.loader.exec_module(branch_protection_check_names)
 class BranchProtectionCheckNamesTests(unittest.TestCase):
     def _write_fixture_repo(self) -> tuple[Path, Path, Path, list[Path]]:
         tmpdir = Path(tempfile.mkdtemp(prefix="branch-protection-checks-"))
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
         manifest_path = tmpdir / "branch_protection_required_checks.json"
         workflow_dir = tmpdir / "workflows"
         workflow_dir.mkdir()
@@ -104,6 +107,101 @@ class BranchProtectionCheckNamesTests(unittest.TestCase):
         )
 
         self.assertTrue(any("Quality Gates / quality-gates" in error for error in errors))
+
+    def test_default_docs_include_branch_protection_runbook(self):
+        self.assertIn(
+            branch_protection_check_names.REPO_ROOT / "docs" / "branch-protection-checks-runbook.md",
+            branch_protection_check_names.DEFAULT_DOCS,
+        )
+
+    def test_parse_workflow_jobs_handles_inline_comments_and_nonstandard_indentation(self):
+        _, _, workflow_dir, _ = self._write_fixture_repo()
+        workflow_path = workflow_dir / "commented-jobs.yml"
+        workflow_path.write_text(
+            "\n".join(
+                [
+                    "name: Test Workflow",
+                    "",
+                    "jobs: # important jobs section",
+                    "   test-job:",
+                    "     name: my-check # canonical name",
+                    "     runs-on: ubuntu-latest",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        jobs = branch_protection_check_names.parse_workflow_jobs(workflow_path)
+
+        self.assertEqual(jobs, [("test-job", "my-check")])
+
+    def test_read_workflow_name_ignores_inline_comments(self):
+        _, _, workflow_dir, _ = self._write_fixture_repo()
+        workflow_path = workflow_dir / "workflow-name-comment.yml"
+        workflow_path.write_text(
+            "\n".join(
+                [
+                    'name: "Test Workflow # canonical" # actual inline comment',
+                    "",
+                    "jobs:",
+                    "  test-job:",
+                    "    runs-on: ubuntu-latest",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        workflow_name = branch_protection_check_names.read_workflow_name(workflow_path)
+
+        self.assertEqual(workflow_name, "Test Workflow # canonical")
+
+    def test_parse_workflow_jobs_ignores_nested_step_and_with_names(self):
+        _, _, workflow_dir, _ = self._write_fixture_repo()
+        workflow_path = workflow_dir / "nested-step-names.yml"
+        workflow_path.write_text(
+            "\n".join(
+                [
+                    "name: Security Audit",
+                    "",
+                    "jobs:",
+                    "  security-audit:",
+                    "    runs-on: ubuntu-latest",
+                    "    steps:",
+                    "      - name: Upload security artifacts",
+                    "        uses: actions/upload-artifact@v4",
+                    "        with:",
+                    "          name: security-scan-artifacts",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        jobs = branch_protection_check_names.parse_workflow_jobs(workflow_path)
+
+        self.assertEqual(jobs, [("security-audit", "security-audit")])
+
+    def test_legacy_doc_aliases_use_last_colon_for_windows_style_paths(self):
+        produced_checks = {
+            "validate": [r"C:\repo\.github\workflows\validate-workflows.yml:validate"],
+        }
+
+        with mock.patch.object(
+            branch_protection_check_names,
+            "read_workflow_name",
+            return_value="Validate workflows",
+        ) as read_workflow_name:
+            aliases = branch_protection_check_names.legacy_doc_aliases_for_required_checks(
+                required_checks=["validate"],
+                produced_checks=produced_checks,
+            )
+
+        self.assertEqual(aliases, ["Validate workflows / validate"])
+        read_workflow_name.assert_called_once_with(
+            Path(r"C:\repo\.github\workflows\validate-workflows.yml")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_branch_protection_check_names.py
+++ b/tests/test_branch_protection_check_names.py
@@ -108,6 +108,37 @@ class BranchProtectionCheckNamesTests(unittest.TestCase):
 
         self.assertTrue(any("Quality Gates / quality-gates" in error for error in errors))
 
+    def test_validation_fails_for_renamed_workflow_aliases_in_docs(self):
+        _, manifest_path, workflow_dir, doc_paths = self._write_fixture_repo()
+        (workflow_dir / "validate-workflows.yml").write_text(
+            "\n".join(
+                [
+                    "name: Validate workflows",
+                    "",
+                    "jobs:",
+                    "  validate:",
+                    "    runs-on: ubuntu-latest",
+                    "  import-test:",
+                    "    runs-on: ubuntu-latest",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        doc_paths[0].write_text(
+            "Checks: `Old Validate Pipeline / validate`, `import-test`\n",
+            encoding="utf-8",
+        )
+
+        errors = branch_protection_check_names.validate_branch_protection_check_names(
+            manifest_path=manifest_path,
+            workflow_dir=workflow_dir,
+            branch="main",
+            doc_paths=doc_paths,
+        )
+
+        self.assertTrue(any("Old Validate Pipeline / validate" in error for error in errors))
+
     def test_default_docs_include_branch_protection_runbook(self):
         self.assertIn(
             branch_protection_check_names.REPO_ROOT / "docs" / "branch-protection-checks-runbook.md",
@@ -183,24 +214,34 @@ class BranchProtectionCheckNamesTests(unittest.TestCase):
 
         self.assertEqual(jobs, [("security-audit", "security-audit")])
 
-    def test_legacy_doc_aliases_use_last_colon_for_windows_style_paths(self):
+    def test_legacy_doc_aliases_include_all_producer_workflow_names(self):
         produced_checks = {
-            "validate": [r"C:\repo\.github\workflows\validate-workflows.yml:validate"],
+            "validate": [
+                r"C:\repo\.github\workflows\validate-workflows.yml:validate",
+                "/tmp/validate-v2.yml:validate",
+            ],
         }
 
         with mock.patch.object(
             branch_protection_check_names,
             "read_workflow_name",
-            return_value="Validate workflows",
+            side_effect=["Validate workflows", "Validate workflows v2"],
         ) as read_workflow_name:
             aliases = branch_protection_check_names.legacy_doc_aliases_for_required_checks(
                 required_checks=["validate"],
                 produced_checks=produced_checks,
             )
 
-        self.assertEqual(aliases, ["Validate workflows / validate"])
-        read_workflow_name.assert_called_once_with(
-            Path(r"C:\repo\.github\workflows\validate-workflows.yml")
+        self.assertEqual(
+            aliases,
+            ["Validate workflows / validate", "Validate workflows v2 / validate"],
+        )
+        self.assertEqual(
+            read_workflow_name.call_args_list,
+            [
+                mock.call(Path(r"C:\repo\.github\workflows\validate-workflows.yml")),
+                mock.call(Path("/tmp/validate-v2.yml")),
+            ],
         )
 
 


### PR DESCRIPTION
## Summary
- add a repo-local canonical manifest for the exact required branch protection check names on `main`
- add local validation that ensures each canonical check still maps to a current GitHub Actions job/check name and rejects stale `Workflow / job` doc strings
- update operator docs with the exact short check names and add a runbook for safely updating branch protection after workflow changes

## Verification
- `python3 -m unittest -v tests.test_branch_protection_check_names`
- `bash scripts/ci/branch_protection_check_names_check.sh`
- `bash scripts/ci/workflow_schema_check.sh`
- `bash scripts/ci/build.sh`

Closes #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated validation of GitHub branch-protection required check names with a CLI and CI check.

* **Documentation**
  * Added branch-protection runbook and updated README, production-readiness checklist, and release process to require verification steps.

* **Tests**
  * Added unit tests exercising the validation logic and repo-fixture scenarios.

* **Chores**
  * Added supervisor journal entry capturing branch-protection verification progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->