### PR TITLE
Parameterize workflow SQL in policy registry flows

### DIFF
--- a/.codex-supervisor/issues/101/issue-journal.md
+++ b/.codex-supervisor/issues/101/issue-journal.md
@@ -1,0 +1,35 @@
+# Issue #101: Parameterize workflow SQL and eliminate raw string interpolation
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/101
+- Branch: codex/issue-101
+- Workspace: .
+- Journal: .codex-supervisor/issues/101/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 7f5735110f3096ffe82e78b06078c69680250398
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T07:46:32.184Z
+
+## Latest Codex Summary
+- Added a focused policy registry SQL check, reproduced raw interpolation in `06_policy_registry_upsert.json`, then parameterized the dynamic policy registry and candidate seed Postgres queries with `queryReplacement`.
+- Updated workflow validation CI to run the new focused check and documented the no-raw-SQL-interpolation rule in `n8n/workflows/README.md`.
+- Focused verification passed: `bash scripts/ci/policy_registry_workflow_check.sh`, `bash scripts/ci/audit_append_workflow_check.sh`, `bash scripts/ci/vector_search_workflow_check.sh`, and `bash scripts/ci/workflow_schema_check.sh`.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Policy registry mutation and lookup workflows are still vulnerable because they build SQL with template interpolation instead of Postgres placeholders and `queryReplacement`.
+- What changed: Added `scripts/ci/policy_registry_workflow_check.sh`; wired it into `.github/workflows/validate-workflows.yml`; parameterized dynamic SQL in `06_policy_registry_upsert.json`, `07_policy_registry_publish.json`, `09_policy_registry_get.json`, `11_policy_candidate_seed.json`, and `12_policy_registry_delete.json`; documented the workflow authoring rule in `n8n/workflows/README.md`.
+- Current blocker: none.
+- Next exact step: Commit the hardened workflows on `codex/issue-101`, then open or update a draft PR if no PR exists yet.
+- Verification gap: Did not run `scripts/ci/n8n_import_test.sh` or the full compose journey; focused workflow checks and schema validation only.
+- Files touched: `.github/workflows/validate-workflows.yml`, `scripts/ci/policy_registry_workflow_check.sh`, `n8n/workflows-v3/06_policy_registry_upsert.json`, `n8n/workflows-v3/07_policy_registry_publish.json`, `n8n/workflows-v3/09_policy_registry_get.json`, `n8n/workflows-v3/11_policy_candidate_seed.json`, `n8n/workflows-v3/12_policy_registry_delete.json`, `n8n/workflows/README.md`.
+- Rollback concern: Low; changes are limited to Postgres node query strings and `queryReplacement` payload bindings for the affected workflows.
+- Last focused command: `bash scripts/ci/workflow_schema_check.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/101/issue-journal.md
+++ b/.codex-supervisor/issues/101/issue-journal.md
@@ -17,6 +17,7 @@
 - Added a focused policy registry SQL check, reproduced raw interpolation in `06_policy_registry_upsert.json`, then parameterized the dynamic policy registry and candidate seed Postgres queries with `queryReplacement`.
 - Updated workflow validation CI to run the new focused check and documented the no-raw-SQL-interpolation rule in `n8n/workflows/README.md`.
 - Focused verification passed: `bash scripts/ci/policy_registry_workflow_check.sh`, `bash scripts/ci/audit_append_workflow_check.sh`, `bash scripts/ci/vector_search_workflow_check.sh`, and `bash scripts/ci/workflow_schema_check.sh`.
+- Commit `7eff8bf76082c8f18b4569ff5ac748f0af08646f` pushed to `origin/codex/issue-101`; draft PR opened as `#107`.
 
 ## Active Failure Context
 - None recorded.
@@ -26,10 +27,10 @@
 - Hypothesis: Policy registry mutation and lookup workflows are still vulnerable because they build SQL with template interpolation instead of Postgres placeholders and `queryReplacement`.
 - What changed: Added `scripts/ci/policy_registry_workflow_check.sh`; wired it into `.github/workflows/validate-workflows.yml`; parameterized dynamic SQL in `06_policy_registry_upsert.json`, `07_policy_registry_publish.json`, `09_policy_registry_get.json`, `11_policy_candidate_seed.json`, and `12_policy_registry_delete.json`; documented the workflow authoring rule in `n8n/workflows/README.md`.
 - Current blocker: none.
-- Next exact step: Commit the hardened workflows on `codex/issue-101`, then open or update a draft PR if no PR exists yet.
+- Next exact step: Monitor PR `#107` checks and address any review or CI follow-ups.
 - Verification gap: Did not run `scripts/ci/n8n_import_test.sh` or the full compose journey; focused workflow checks and schema validation only.
 - Files touched: `.github/workflows/validate-workflows.yml`, `scripts/ci/policy_registry_workflow_check.sh`, `n8n/workflows-v3/06_policy_registry_upsert.json`, `n8n/workflows-v3/07_policy_registry_publish.json`, `n8n/workflows-v3/09_policy_registry_get.json`, `n8n/workflows-v3/11_policy_candidate_seed.json`, `n8n/workflows-v3/12_policy_registry_delete.json`, `n8n/workflows/README.md`.
 - Rollback concern: Low; changes are limited to Postgres node query strings and `queryReplacement` payload bindings for the affected workflows.
-- Last focused command: `bash scripts/ci/workflow_schema_check.sh`
+- Last focused command: `gh pr create --draft --base main --head codex/issue-101 --title "Parameterize workflow SQL in policy registry flows" --body-file -`
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -24,6 +24,7 @@ jobs:
           bash scripts/ci/audit_append_workflow_check.sh
           bash scripts/ci/executor_dispatch_workflow_check.sh
           bash scripts/ci/policy_approval_workflow_check.sh
+          bash scripts/ci/policy_registry_workflow_check.sh
 
       - name: Check Slack ingress security regression
         run: python3 -m unittest -v tests.test_slack_ingress_security

--- a/n8n/workflows-v3/06_policy_registry_upsert.json
+++ b/n8n/workflows-v3/06_policy_registry_upsert.json
@@ -121,7 +121,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO policy_workflows (workflow_id, task_type, tenant_id, scope_pattern, constraints_jsonb, enabled) VALUES ('{{ $json.workflow_id.replace(/'/g, \"''\") }}', '{{ $json.task_type.replace(/'/g, \"''\") }}', '{{ $json.tenant_id.replace(/'/g, \"''\") }}', '{{ $json.scope_pattern.replace(/'/g, \"''\") }}', '{{ JSON.stringify($json.constraints || {}).replace(/'/g, \"''\") }}'::jsonb, {{ $json.enabled ? 'true' : 'false' }}) ON CONFLICT (workflow_id, task_type, tenant_id, scope_pattern) DO UPDATE SET constraints_jsonb = EXCLUDED.constraints_jsonb, enabled = EXCLUDED.enabled, updated_at = NOW();"
+        "query": "INSERT INTO policy_workflows (workflow_id, task_type, tenant_id, scope_pattern, constraints_jsonb, enabled) VALUES ($1, $2, $3, $4, $5::jsonb, $6) ON CONFLICT (workflow_id, task_type, tenant_id, scope_pattern) DO UPDATE SET constraints_jsonb = EXCLUDED.constraints_jsonb, enabled = EXCLUDED.enabled, updated_at = NOW();",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $json.workflow_id,\n  $json.task_type,\n  $json.tenant_id,\n  $json.scope_pattern,\n  JSON.stringify($json.constraints || {}),\n  Boolean($json.enabled)\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -140,7 +143,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ('draft', 'upsert', '{{ $('Validate Input').first().json.actor.replace(/'/g, \"''\") }}', 'ok', '{{ JSON.stringify($('Validate Input').first().json).replace(/'/g, \"''\") }}'::jsonb);"
+        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ('draft', 'upsert', $1, 'ok', $2::jsonb);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $('Validate Input').first().json.actor,\n  JSON.stringify($('Validate Input').first().json)\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows-v3/07_policy_registry_publish.json
+++ b/n8n/workflows-v3/07_policy_registry_publish.json
@@ -91,7 +91,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "WITH payload AS ( SELECT COALESCE(jsonb_agg(jsonb_build_object('workflow_id', workflow_id,'task_type', task_type,'tenant_id', tenant_id,'scope_pattern', scope_pattern,'constraints', constraints_jsonb,'enabled', enabled)), '[]'::jsonb) AS workflows FROM policy_workflows ) INSERT INTO policy_revisions (revision_id, status, payload_jsonb, notes, author, is_active, published_at) SELECT '{{ $json.revision_id.replace(/'/g, \"''\") }}', 'published', jsonb_build_object('workflows', payload.workflows), '{{ $json.notes.replace(/'/g, \"''\") }}', '{{ $json.actor.replace(/'/g, \"''\") }}', true, NOW() FROM payload ON CONFLICT (revision_id) DO UPDATE SET status='published', payload_jsonb=EXCLUDED.payload_jsonb, notes=EXCLUDED.notes, author=EXCLUDED.author, is_active=true, published_at=NOW(); UPDATE policy_revisions SET is_active=false WHERE revision_id <> '{{ $json.revision_id.replace(/'/g, \"''\") }}';"
+        "query": "WITH payload AS ( SELECT COALESCE(jsonb_agg(jsonb_build_object('workflow_id', workflow_id,'task_type', task_type,'tenant_id', tenant_id,'scope_pattern', scope_pattern,'constraints', constraints_jsonb,'enabled', enabled)), '[]'::jsonb) AS workflows FROM policy_workflows ) INSERT INTO policy_revisions (revision_id, status, payload_jsonb, notes, author, is_active, published_at) SELECT $1, 'published', jsonb_build_object('workflows', payload.workflows), $2, $3, true, NOW() FROM payload ON CONFLICT (revision_id) DO UPDATE SET status='published', payload_jsonb=EXCLUDED.payload_jsonb, notes=EXCLUDED.notes, author=EXCLUDED.author, is_active=true, published_at=NOW(); UPDATE policy_revisions SET is_active=false WHERE revision_id <> $1;",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $json.revision_id,\n  $json.notes,\n  $json.actor\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -110,7 +113,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ('{{ $('Build Publish Payload').first().json.revision_id.replace(/'/g, \"''\") }}', 'publish', '{{ $('Build Publish Payload').first().json.actor.replace(/'/g, \"''\") }}', 'ok', '{{ JSON.stringify({ notes: $('Build Publish Payload').first().json.notes }).replace(/'/g, \"''\") }}'::jsonb);"
+        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ($1, 'publish', $2, 'ok', $3::jsonb);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $('Build Publish Payload').first().json.revision_id,\n  $('Build Publish Payload').first().json.actor,\n  JSON.stringify({ notes: $('Build Publish Payload').first().json.notes })\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -129,7 +135,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT payload_jsonb FROM policy_revisions WHERE revision_id='{{ $('Build Publish Payload').first().json.revision_id.replace(/'/g, \"''\") }}' LIMIT 1;"
+        "query": "SELECT payload_jsonb FROM policy_revisions WHERE revision_id=$1 LIMIT 1;",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $('Build Publish Payload').first().json.revision_id\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows-v3/07_policy_registry_publish.json
+++ b/n8n/workflows-v3/07_policy_registry_publish.json
@@ -91,9 +91,9 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "WITH payload AS ( SELECT COALESCE(jsonb_agg(jsonb_build_object('workflow_id', workflow_id,'task_type', task_type,'tenant_id', tenant_id,'scope_pattern', scope_pattern,'constraints', constraints_jsonb,'enabled', enabled)), '[]'::jsonb) AS workflows FROM policy_workflows ) INSERT INTO policy_revisions (revision_id, status, payload_jsonb, notes, author, is_active, published_at) SELECT $1, 'published', jsonb_build_object('workflows', payload.workflows), $2, $3, true, NOW() FROM payload ON CONFLICT (revision_id) DO UPDATE SET status='published', payload_jsonb=EXCLUDED.payload_jsonb, notes=EXCLUDED.notes, author=EXCLUDED.author, is_active=true, published_at=NOW(); UPDATE policy_revisions SET is_active=false WHERE revision_id <> $1;",
+        "query": "WITH payload AS ( SELECT COALESCE(jsonb_agg(jsonb_build_object('workflow_id', workflow_id,'task_type', task_type,'tenant_id', tenant_id,'scope_pattern', scope_pattern,'constraints', constraints_jsonb,'enabled', enabled)), '[]'::jsonb) AS workflows FROM policy_workflows ), upserted AS ( INSERT INTO policy_revisions (revision_id, status, payload_jsonb, notes, author, is_active, published_at) SELECT $1, 'published', jsonb_build_object('workflows', payload.workflows), $2, $3, true, NOW() FROM payload ON CONFLICT (revision_id) DO UPDATE SET status='published', payload_jsonb=EXCLUDED.payload_jsonb, notes=EXCLUDED.notes, author=EXCLUDED.author, is_active=true, published_at=NOW() RETURNING revision_id ), deactivated AS ( UPDATE policy_revisions SET is_active=false WHERE revision_id <> $4 RETURNING revision_id ) SELECT upserted.revision_id, COALESCE((SELECT count(*) FROM deactivated), 0) AS deactivated_count FROM upserted;",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  $json.revision_id,\n  $json.notes,\n  $json.actor\n] }}"
+          "queryReplacement": "={{ [\n  $json.revision_id,\n  $json.notes,\n  $json.actor,\n  $json.revision_id\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",

--- a/n8n/workflows-v3/09_policy_registry_get.json
+++ b/n8n/workflows-v3/09_policy_registry_get.json
@@ -121,7 +121,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT workflow_id, task_type, tenant_id, scope_pattern, constraints_jsonb, enabled, created_at, updated_at FROM policy_workflows WHERE workflow_id='{{ $json.workflow_id.replace(/'/g, \"''\") }}' AND task_type='{{ $json.task_type.replace(/'/g, \"''\") }}' ORDER BY updated_at DESC LIMIT 1;"
+        "query": "SELECT workflow_id, task_type, tenant_id, scope_pattern, constraints_jsonb, enabled, created_at, updated_at FROM policy_workflows WHERE workflow_id=$1 AND task_type=$2 ORDER BY updated_at DESC LIMIT 1;",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $json.workflow_id,\n  $json.task_type\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows-v3/11_policy_candidate_seed.json
+++ b/n8n/workflows-v3/11_policy_candidate_seed.json
@@ -139,7 +139,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO policy_candidate_events (task_type, tenant_id, scope, source)\nVALUES ('{{ $json.task_type.replace(/'/g, \"''\") }}', '{{ $json.tenant_id.replace(/'/g, \"''\") }}', '{{ $json.scope.replace(/'/g, \"''\") }}', '{{ ($json.metadata.source || '11_policy_candidate_seed').replace(/'/g, \"''\") }}')\nRETURNING id, task_type, tenant_id, scope, created_at;"
+        "query": "INSERT INTO policy_candidate_events (task_type, tenant_id, scope, source)\nVALUES ($1, $2, $3, $4)\nRETURNING id, task_type, tenant_id, scope, created_at;",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $json.task_type,\n  $json.tenant_id,\n  $json.scope,\n  $json.metadata.source || '11_policy_candidate_seed'\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows-v3/12_policy_registry_delete.json
+++ b/n8n/workflows-v3/12_policy_registry_delete.json
@@ -121,7 +121,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "DELETE FROM policy_workflows WHERE workflow_id='{{ $json.workflow_id.replace(/'/g, \"''\") }}' AND task_type='{{ $json.task_type.replace(/'/g, \"''\") }}' AND tenant_id='{{ $json.tenant_id.replace(/'/g, \"''\") }}' AND scope_pattern='{{ $json.scope_pattern.replace(/'/g, \"''\") }}';"
+        "query": "DELETE FROM policy_workflows WHERE workflow_id=$1 AND task_type=$2 AND tenant_id=$3 AND scope_pattern=$4;",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $json.workflow_id,\n  $json.task_type,\n  $json.tenant_id,\n  $json.scope_pattern\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -140,7 +143,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ('draft', 'delete', '{{ $('Validate Input').first().json.actor.replace(/'/g, \"''\") }}', 'ok', '{{ JSON.stringify($('Validate Input').first().json).replace(/'/g, \"''\") }}'::jsonb);"
+        "query": "INSERT INTO policy_publish_logs (revision_id, action, actor, result, details_jsonb) VALUES ('draft', 'delete', $1, 'ok', $2::jsonb);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $('Validate Input').first().json.actor,\n  JSON.stringify($('Validate Input').first().json)\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows/README.md
+++ b/n8n/workflows/README.md
@@ -234,6 +234,7 @@ Policy quality queries are available at:
 ## Security Notes
 
 - All workflows validate inputs before database writes
+- Never interpolate request data directly into SQL strings in Postgres nodes; use `$1`, `$2`, ... placeholders with `additionalFields.queryReplacement`
 - Secrets patterns are blocked (API keys, tokens, private keys)
 - Audit events are append-only
 - Postgres credential uses internal Docker network (no SSL needed)

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -1,6 +1,190 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Parse the stored n8n expression statically so the gate can validate binding counts without executing workflow code.
+count_n8n_query_replacement_bindings() {
+  local query_replacement="$1"
+  local node_name="$2"
+  local workflow_path="$3"
+
+  awk -v node_name="$node_name" -v workflow_path="$workflow_path" '
+    function fail(reason) {
+      printf "%s for '\''%s'\'' in %s\n", reason, node_name, workflow_path > "/dev/stderr"
+      exit 1
+    }
+
+    {
+      expr = expr $0 "\n"
+    }
+
+    END {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", expr)
+      if (expr ~ /^=\{\{/) {
+        sub(/^=\{\{[[:space:]]*/, "", expr)
+        sub(/[[:space:]]*\}\}$/, "", expr)
+      }
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", expr)
+
+      if (substr(expr, 1, 1) != "[") {
+        fail("queryReplacement must be an array expression")
+      }
+
+      count = 0
+      array_depth = 0
+      brace_depth = 0
+      paren_depth = 0
+      in_token = 0
+      in_single = 0
+      in_double = 0
+      in_template = 0
+      escape = 0
+
+      for (i = 1; i <= length(expr); i++) {
+        ch = substr(expr, i, 1)
+
+        if (escape) {
+          escape = 0
+          continue
+        }
+
+        if (in_single) {
+          if (ch == "\\") {
+            escape = 1
+          } else if (ch == "'\''") {
+            in_single = 0
+          }
+          continue
+        }
+
+        if (in_double) {
+          if (ch == "\\") {
+            escape = 1
+          } else if (ch == "\"") {
+            in_double = 0
+          }
+          continue
+        }
+
+        if (in_template) {
+          if (ch == "\\") {
+            escape = 1
+          } else if (ch == "`") {
+            in_template = 0
+          }
+          continue
+        }
+
+        if (ch == "'\''") {
+          in_single = 1
+          if (array_depth >= 1) {
+            in_token = 1
+          }
+          continue
+        }
+
+        if (ch == "\"") {
+          in_double = 1
+          if (array_depth >= 1) {
+            in_token = 1
+          }
+          continue
+        }
+
+        if (ch == "`") {
+          in_template = 1
+          if (array_depth >= 1) {
+            in_token = 1
+          }
+          continue
+        }
+
+        if (ch ~ /[[:space:]]/) {
+          continue
+        }
+
+        if (array_depth == 0) {
+          if (ch != "[") {
+            fail("queryReplacement must contain a single array expression")
+          }
+          array_depth = 1
+          continue
+        }
+
+        if (ch == "," && array_depth == 1 && brace_depth == 0 && paren_depth == 0) {
+          if (!in_token) {
+            fail("queryReplacement contains an empty binding slot")
+          }
+          count++
+          in_token = 0
+          continue
+        }
+
+        if (ch == "]" && array_depth == 1 && brace_depth == 0 && paren_depth == 0) {
+          if (in_token) {
+            count++
+            in_token = 0
+          }
+          array_depth = 0
+          continue
+        }
+
+        if (ch == "[") {
+          array_depth++
+          in_token = 1
+          continue
+        }
+
+        if (ch == "]") {
+          if (array_depth <= 1) {
+            fail("queryReplacement has an unexpected closing bracket")
+          }
+          array_depth--
+          continue
+        }
+
+        if (ch == "{") {
+          brace_depth++
+          in_token = 1
+          continue
+        }
+
+        if (ch == "}") {
+          if (brace_depth == 0) {
+            fail("queryReplacement has an unexpected closing brace")
+          }
+          brace_depth--
+          continue
+        }
+
+        if (ch == "(") {
+          paren_depth++
+          in_token = 1
+          continue
+        }
+
+        if (ch == ")") {
+          if (paren_depth == 0) {
+            fail("queryReplacement has an unexpected closing parenthesis")
+          }
+          paren_depth--
+          continue
+        }
+
+        in_token = 1
+      }
+
+      if (escape || in_single || in_double || in_template) {
+        fail("queryReplacement has an unterminated string literal")
+      }
+      if (array_depth != 0 || brace_depth != 0 || paren_depth != 0) {
+        fail("queryReplacement has unbalanced delimiters")
+      }
+
+      print count
+    }
+  ' <<<"$query_replacement"
+}
+
 require_parameterized_query() {
   local workflow_path="$1"
   local node_name="$2"
@@ -10,6 +194,8 @@ require_parameterized_query() {
   local match_count
   local query
   local query_replacement
+  local replacement_count
+  local max_placeholder
   matched_nodes="$(jq -c --arg node_name "$node_name" '[.nodes[] | select(.name == $node_name)]' "$workflow_path")"
   match_count="$(jq -r 'length' <<<"$matched_nodes")"
 
@@ -33,6 +219,14 @@ require_parameterized_query() {
 
   if [[ -z "$query_replacement" || "$query_replacement" == "null" ]]; then
     echo "Missing queryReplacement for '${node_name}' in ${workflow_path}" >&2
+    exit 1
+  fi
+
+  replacement_count="$(count_n8n_query_replacement_bindings "$query_replacement" "$node_name" "$workflow_path")"
+  max_placeholder="$(grep -oE '\$[0-9]+' <<<"$query" | tr -d '$' | sort -n | tail -1 || true)"
+
+  if [[ -n "$max_placeholder" && "$replacement_count" -lt "$max_placeholder" ]]; then
+    echo "queryReplacement provides ${replacement_count} binding(s), but '${node_name}' query references up to \$${max_placeholder} in ${workflow_path}" >&2
     exit 1
   fi
 

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_parameterized_query() {
+  local workflow_path="$1"
+  local node_name="$2"
+  shift 2
+
+  local query
+  local query_replacement
+  query="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.name == $node_name) | .parameters.query' "$workflow_path")"
+  query_replacement="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.name == $node_name) | .parameters.additionalFields.queryReplacement' "$workflow_path")"
+
+  if [[ -z "$query" || "$query" == "null" ]]; then
+    echo "Query not found for '${node_name}' in ${workflow_path}" >&2
+    exit 1
+  fi
+
+  if grep -Fq "{{" <<<"$query"; then
+    echo "Raw SQL interpolation detected in '${node_name}' for ${workflow_path}" >&2
+    exit 1
+  fi
+
+  if [[ -z "$query_replacement" || "$query_replacement" == "null" ]]; then
+    echo "Missing queryReplacement for '${node_name}' in ${workflow_path}" >&2
+    exit 1
+  fi
+
+  for pattern in "$@"; do
+    if ! grep -Fq "$pattern" <<<"$query"; then
+      echo "Missing '${pattern}' in '${node_name}' query for ${workflow_path}" >&2
+      exit 1
+    fi
+  done
+}
+
+check_policy_registry_workflows() {
+  local workflow_path="n8n/workflows-v3/$1"
+
+  if [[ ! -f "$workflow_path" ]]; then
+    echo "Workflow file not found: ${workflow_path}" >&2
+    exit 1
+  fi
+
+  case "$1" in
+    06_policy_registry_upsert.json)
+      require_parameterized_query "$workflow_path" "Upsert Workflow Rule" '$1' '$2' '$3' '$4' '$5::jsonb' '$6'
+      require_parameterized_query "$workflow_path" "Insert Upsert Log" '$1' '$2::jsonb'
+      ;;
+    07_policy_registry_publish.json)
+      require_parameterized_query "$workflow_path" "Publish Revision" '$1' '$2' '$3' '$1'
+      require_parameterized_query "$workflow_path" "Insert Publish Log" '$1' '$2' '$3::jsonb'
+      require_parameterized_query "$workflow_path" "Load Published Payload" '$1'
+      ;;
+    09_policy_registry_get.json)
+      require_parameterized_query "$workflow_path" "Get Workflow Rule" '$1' '$2'
+      ;;
+    11_policy_candidate_seed.json)
+      require_parameterized_query "$workflow_path" "Insert Seed Episode" '$1' '$2' '$3' '$4'
+      ;;
+    12_policy_registry_delete.json)
+      require_parameterized_query "$workflow_path" "Delete Workflow Rule" '$1' '$2' '$3' '$4'
+      require_parameterized_query "$workflow_path" "Insert Delete Log" '$1' '$2::jsonb'
+      ;;
+    *)
+      echo "Unhandled workflow fixture: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+check_policy_registry_workflows "06_policy_registry_upsert.json"
+check_policy_registry_workflows "07_policy_registry_publish.json"
+check_policy_registry_workflows "09_policy_registry_get.json"
+check_policy_registry_workflows "11_policy_candidate_seed.json"
+check_policy_registry_workflows "12_policy_registry_delete.json"
+
+echo "Policy registry workflow SQL checks passed."

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -6,10 +6,20 @@ require_parameterized_query() {
   local node_name="$2"
   shift 2
 
+  local matched_nodes
+  local match_count
   local query
   local query_replacement
-  query="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.name == $node_name) | .parameters.query' "$workflow_path")"
-  query_replacement="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.name == $node_name) | .parameters.additionalFields.queryReplacement' "$workflow_path")"
+  matched_nodes="$(jq -c --arg node_name "$node_name" '[.nodes[] | select(.name == $node_name)]' "$workflow_path")"
+  match_count="$(jq -r 'length' <<<"$matched_nodes")"
+
+  if [[ "$match_count" -ne 1 ]]; then
+    echo "Expected exactly 1 node named '${node_name}' in ${workflow_path}, found ${match_count}" >&2
+    exit 1
+  fi
+
+  query="$(jq -r '.[0].parameters.query' <<<"$matched_nodes")"
+  query_replacement="$(jq -r '.[0].parameters.additionalFields.queryReplacement' <<<"$matched_nodes")"
 
   if [[ -z "$query" || "$query" == "null" ]]; then
     echo "Query not found for '${node_name}' in ${workflow_path}" >&2
@@ -48,7 +58,7 @@ check_policy_registry_workflows() {
       require_parameterized_query "$workflow_path" "Insert Upsert Log" '$1' '$2::jsonb'
       ;;
     07_policy_registry_publish.json)
-      require_parameterized_query "$workflow_path" "Publish Revision" '$1' '$2' '$3' '$1'
+      require_parameterized_query "$workflow_path" "Publish Revision" '$1' '$2' '$3' '$4'
       require_parameterized_query "$workflow_path" "Insert Publish Log" '$1' '$2' '$3::jsonb'
       require_parameterized_query "$workflow_path" "Load Published Payload" '$1'
       ;;

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -37,7 +37,16 @@ require_parameterized_query() {
   fi
 
   for pattern in "$@"; do
-    if ! grep -Fq "$pattern" <<<"$query"; then
+    if [[ "$pattern" =~ ^\$([0-9]+)$ ]]; then
+      local idx
+      local placeholder_regex
+      idx="${BASH_REMATCH[1]}"
+      printf -v placeholder_regex '(^|[^0-9])\\$%s([^0-9]|$)' "$idx"
+      if ! grep -Eq "$placeholder_regex" <<<"$query"; then
+        echo "Missing '${pattern}' in '${node_name}' query for ${workflow_path}" >&2
+        exit 1
+      fi
+    elif ! grep -Fq -- "$pattern" <<<"$query"; then
       echo "Missing '${pattern}' in '${node_name}' query for ${workflow_path}" >&2
       exit 1
     fi

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -37,10 +37,27 @@ count_n8n_query_replacement_bindings() {
       in_single = 0
       in_double = 0
       in_template = 0
+      in_line_comment = 0
+      in_block_comment = 0
       escape = 0
 
       for (i = 1; i <= length(expr); i++) {
         ch = substr(expr, i, 1)
+
+        if (in_line_comment) {
+          if (ch == "\n") {
+            in_line_comment = 0
+          }
+          continue
+        }
+
+        if (in_block_comment) {
+          if (ch == "*" && i < length(expr) && substr(expr, i + 1, 1) == "/") {
+            in_block_comment = 0
+            i++
+          }
+          continue
+        }
 
         if (escape) {
           escape = 0
@@ -96,6 +113,20 @@ count_n8n_query_replacement_bindings() {
             in_token = 1
           }
           continue
+        }
+
+        if (ch == "/" && i < length(expr)) {
+          next_ch = substr(expr, i + 1, 1)
+          if (next_ch == "/") {
+            in_line_comment = 1
+            i++
+            continue
+          }
+          if (next_ch == "*") {
+            in_block_comment = 1
+            i++
+            continue
+          }
         }
 
         if (ch ~ /[[:space:]]/) {
@@ -175,6 +206,9 @@ count_n8n_query_replacement_bindings() {
 
       if (escape || in_single || in_double || in_template) {
         fail("queryReplacement has an unterminated string literal")
+      }
+      if (in_block_comment) {
+        fail("queryReplacement has an unterminated block comment")
       }
       if (array_depth != 0 || brace_depth != 0 || paren_depth != 0) {
         fail("queryReplacement has unbalanced delimiters")

--- a/scripts/ci/policy_registry_workflow_check.sh
+++ b/scripts/ci/policy_registry_workflow_check.sh
@@ -219,6 +219,189 @@ count_n8n_query_replacement_bindings() {
   ' <<<"$query_replacement"
 }
 
+strip_sql_noncode() {
+  awk '
+    function emit_replacement(ch) {
+      if (ch == "\n") {
+        printf "\n"
+      } else {
+        printf " "
+      }
+    }
+
+    function consume_dollar_tag(text, start,    ch, i, tag) {
+      if (substr(text, start, 1) != "$") {
+        return ""
+      }
+
+      ch = substr(text, start + 1, 1)
+      if (ch == "$") {
+        return "$$"
+      }
+
+      if (ch !~ /[A-Za-z_]/) {
+        return ""
+      }
+
+      tag = "$" ch
+      for (i = start + 2; i <= length(text); i++) {
+        ch = substr(text, i, 1)
+        if (ch == "$") {
+          return tag "$"
+        }
+        if (ch !~ /[A-Za-z0-9_]/) {
+          return ""
+        }
+        tag = tag ch
+      }
+
+      return ""
+    }
+
+    {
+      sql = sql $0 "\n"
+    }
+
+    END {
+      state = "code"
+      block_depth = 0
+      dollar_tag = ""
+
+      for (i = 1; i <= length(sql); i++) {
+        ch = substr(sql, i, 1)
+        next_ch = (i < length(sql)) ? substr(sql, i + 1, 1) : ""
+
+        if (state == "line_comment") {
+          emit_replacement(ch)
+          if (ch == "\n") {
+            state = "code"
+          }
+          continue
+        }
+
+        if (state == "block_comment") {
+          if (ch == "/" && next_ch == "*") {
+            emit_replacement(ch)
+            emit_replacement(next_ch)
+            block_depth++
+            i++
+            continue
+          }
+
+          if (ch == "*" && next_ch == "/") {
+            emit_replacement(ch)
+            emit_replacement(next_ch)
+            block_depth--
+            i++
+            if (block_depth == 0) {
+              state = "code"
+            }
+            continue
+          }
+
+          emit_replacement(ch)
+          continue
+        }
+
+        if (state == "single_quote") {
+          if (ch == "'\''" && next_ch == "'\''") {
+            emit_replacement(ch)
+            emit_replacement(next_ch)
+            i++
+            continue
+          }
+
+          emit_replacement(ch)
+          if (ch == "'\''") {
+            state = "code"
+          }
+          continue
+        }
+
+        if (state == "double_quote") {
+          if (ch == "\"" && next_ch == "\"") {
+            emit_replacement(ch)
+            emit_replacement(next_ch)
+            i++
+            continue
+          }
+
+          emit_replacement(ch)
+          if (ch == "\"") {
+            state = "code"
+          }
+          continue
+        }
+
+        if (state == "dollar_quote") {
+          if (substr(sql, i, length(dollar_tag)) == dollar_tag) {
+            for (j = 1; j <= length(dollar_tag); j++) {
+              emit_replacement(substr(dollar_tag, j, 1))
+            }
+            i += length(dollar_tag) - 1
+            state = "code"
+            continue
+          }
+
+          emit_replacement(ch)
+          continue
+        }
+
+        if (ch == "-" && next_ch == "-") {
+          emit_replacement(ch)
+          emit_replacement(next_ch)
+          state = "line_comment"
+          i++
+          continue
+        }
+
+        if (ch == "/" && next_ch == "*") {
+          emit_replacement(ch)
+          emit_replacement(next_ch)
+          state = "block_comment"
+          block_depth = 1
+          i++
+          continue
+        }
+
+        if (ch == "'\''") {
+          emit_replacement(ch)
+          state = "single_quote"
+          continue
+        }
+
+        if (ch == "\"") {
+          emit_replacement(ch)
+          state = "double_quote"
+          continue
+        }
+
+        dollar_tag = consume_dollar_tag(sql, i)
+        if (dollar_tag != "") {
+          for (j = 1; j <= length(dollar_tag); j++) {
+            emit_replacement(substr(dollar_tag, j, 1))
+          }
+          i += length(dollar_tag) - 1
+          state = "dollar_quote"
+          continue
+        }
+
+        printf "%s", ch
+      }
+
+      if (state == "block_comment") {
+        print "SQL contains an unterminated block comment" > "/dev/stderr"
+        exit 1
+      }
+
+      if (state == "single_quote" || state == "double_quote" || state == "dollar_quote") {
+        print "SQL contains an unterminated quoted literal" > "/dev/stderr"
+        exit 1
+      }
+    }
+  '
+}
+
 require_parameterized_query() {
   local workflow_path="$1"
   local node_name="$2"
@@ -230,6 +413,7 @@ require_parameterized_query() {
   local query_replacement
   local replacement_count
   local max_placeholder
+  local normalized_query
   matched_nodes="$(jq -c --arg node_name "$node_name" '[.nodes[] | select(.name == $node_name)]' "$workflow_path")"
   match_count="$(jq -r 'length' <<<"$matched_nodes")"
 
@@ -257,7 +441,8 @@ require_parameterized_query() {
   fi
 
   replacement_count="$(count_n8n_query_replacement_bindings "$query_replacement" "$node_name" "$workflow_path")"
-  max_placeholder="$(grep -oE '\$[0-9]+' <<<"$query" | tr -d '$' | sort -n | tail -1 || true)"
+  normalized_query="$(strip_sql_noncode <<<"$query")"
+  max_placeholder="$(grep -oE '\$[0-9]+' <<<"$normalized_query" | tr -d '$' | sort -n | tail -1 || true)"
 
   if [[ -n "$max_placeholder" && "$replacement_count" -lt "$max_placeholder" ]]; then
     echo "queryReplacement provides ${replacement_count} binding(s), but '${node_name}' query references up to \$${max_placeholder} in ${workflow_path}" >&2
@@ -270,11 +455,11 @@ require_parameterized_query() {
       local placeholder_regex
       idx="${BASH_REMATCH[1]}"
       printf -v placeholder_regex '(^|[^0-9])\\$%s([^0-9]|$)' "$idx"
-      if ! grep -Eq "$placeholder_regex" <<<"$query"; then
+      if ! grep -Eq "$placeholder_regex" <<<"$normalized_query"; then
         echo "Missing '${pattern}' in '${node_name}' query for ${workflow_path}" >&2
         exit 1
       fi
-    elif ! grep -Fq -- "$pattern" <<<"$query"; then
+    elif ! grep -Fq -- "$pattern" <<<"$normalized_query"; then
       echo "Missing '${pattern}' in '${node_name}' query for ${workflow_path}" >&2
       exit 1
     fi


### PR DESCRIPTION
## Summary
- add a focused policy registry workflow SQL check to reproduce and prevent raw interpolation regressions
- convert dynamic Postgres queries in the policy registry and candidate seed workflows to parameterized queries with `queryReplacement`
- document the no-raw-SQL-interpolation rule for workflow authors

## Verification
- `bash scripts/ci/policy_registry_workflow_check.sh`
- `bash scripts/ci/audit_append_workflow_check.sh`
- `bash scripts/ci/vector_search_workflow_check.sh`
- `bash scripts/ci/workflow_schema_check.sh`

Closes #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened workflow SQL by switching from inline interpolation to parameterized queries across policy-related workflows.

* **Continuous Integration**
  * Added a CI validation step and script that enforces parameterized SQL in workflow fixtures and fails on raw interpolation or mismatched bindings.

* **Documentation**
  * Added workflow authoring guidance requiring SQL parameterization and an issue journal entry documenting validation progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->