### PR TITLE
Strengthen memory_ingest SQL interpolation guard

### DIFF
--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -18,11 +18,11 @@ Validated the two remaining CodeRabbit findings against head `996b396` and confi
 
 Extended [tests/test_memory_ingest_workflow_check.py](tests/test_memory_ingest_workflow_check.py) with regressions for both review threads: one proves a non-Postgres node named `Insert Vector` is ignored, and one proves a two-placeholder query with a one-item replacement array fails with the new binding-count error. Focused verification passed locally after the patch.
 
-Summary: Addressed the two remaining automated review threads by hardening the memory-ingest CI selector and bind-count validation.
-State hint: local_review_fix
+Summary: Addressed the two remaining automated review threads, committed the CI guard hardening as `ef1782a`, and pushed `codex/issue-108`.
+State hint: waiting_ci
 Blocked reason: none
 Tests: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`
-Next action: Commit and push the review-fix checkpoint on `codex/issue-108`, then monitor PR #110 for refreshed CI/review state.
+Next action: Monitor PR #110 on head `ef1782a` for refreshed CI/review state and address any follow-up if it appears.
 Failure signature: none
 
 ## Active Failure Context
@@ -38,11 +38,11 @@ Failure signature: none
 - Hypothesis: The remaining review risk was not just missing workflow coverage; the CI guard could also inspect the wrong `Insert Vector` node by name and allow under-bound `queryReplacement` arrays to pass.
 - What changed: Tightened `check_insert_vector_contract()` to select only `n8n-nodes-base.postgres` nodes named `Insert Vector`, added static bind counting for parameterized `queryReplacement` array expressions, and extended the focused unit tests to cover both the selector hardening and the missing-binding failure mode.
 - Current blocker: none
-- Next exact step: Push the current checkpoint and watch PR #110 for refreshed CI plus updated review-thread state.
+- Next exact step: Watch PR #110 for refreshed CI plus updated review-thread state after pushed head `ef1782a`.
 - Verification gap: Focused verification passed for the CI guard and its regression tests; broader repo-wide test/lint suites remain unrun in this turn.
 - Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; .codex-supervisor/issues/108/issue-journal.md
 - Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
-- Last focused command: `bash scripts/ci/memory_ingest_workflow_check.sh`
+- Last focused command: `git push origin codex/issue-108`
 ### Scratchpad
 - Local review triage: the stale issue-journal status comment is already obsolete in the live file; the actionable local fixes were PRRT_kwDORd-8zc56Tc8K, PRRT_kwDORd-8zc56Tc8N, PRRT_kwDORd-8zc56Tc8O, PRRT_kwDORd-8zc56Tc8P, and PRRT_kwDORd-8zc56Tc8R.
 - Commands run this turn: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`; `git diff -- scripts/ci/memory_ingest_workflow_check.sh tests/test_memory_ingest_workflow_check.py`.

--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -39,13 +39,13 @@ Failure signature: PRRT_kwDORd-8zc56Tc8G|PRRT_kwDORd-8zc56Tc8K|PRRT_kwDORd-8zc56
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The CI guard only inspected `Insert Vector` in two workflows, so raw `{{ ... }}` interpolation in other memory-ingest Postgres nodes could ship undetected.
-- What changed: Applied the current PR review fixes on top of `def7764`: hardened all three `Insert Facts` confidence arrays against `NaN`, changed the v3 audit fallback token from `allowed` to `allow`, tightened the CI `Insert Vector` contract to require an actual `.json.content_hash` bind, and extended the focused regression test to prove the stricter failure mode.
+- What changed: Applied the current PR review fixes on top of `def7764`, committed them as `c1ff3de`, and pushed `codex/issue-108`: hardened all three `Insert Facts` confidence arrays against `NaN`, changed the v3 audit fallback token from `allowed` to `allow`, tightened the CI `Insert Vector` contract to require an actual `.json.content_hash` bind, and extended the focused regression test to prove the stricter failure mode.
 - Current blocker: none
-- Next exact step: Commit these review fixes on `codex/issue-108`, then push the branch and refresh PR #110 for another review/CI pass.
+- Next exact step: Monitor PR #110 for updated CI and review state after `c1ff3de`, then address any remaining actionable threads if they appear.
 - Verification gap: Focused verification passed again; broader lint/test suites have still not been run in this turn.
 - Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; n8n/workflows/01_memory_ingest.json; n8n/workflows-v3/01_memory_ingest.json; n8n/workflows/01_memory_ingest_v3_cached.json; .codex-supervisor/issues/108/issue-journal.md
 - Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
-- Last focused command: `bash scripts/ci/memory_ingest_workflow_check.sh`
+- Last focused command: `git push origin codex/issue-108`
 ### Scratchpad
 - Local review triage: the stale issue-journal status comment is already obsolete in the live file; the actionable local fixes were PRRT_kwDORd-8zc56Tc8K, PRRT_kwDORd-8zc56Tc8N, PRRT_kwDORd-8zc56Tc8O, PRRT_kwDORd-8zc56Tc8P, and PRRT_kwDORd-8zc56Tc8R.
 - Commands run this turn: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`.

--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #108: Strengthen memory_ingest CI to detect raw SQL interpolation in every Postgres node
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/108
+- Branch: codex/issue-108
+- Workspace: .
+- Journal: .codex-supervisor/issues/108/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: d6ac7291299d7ba3b1148c078cc07f74681d589c
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-11T14:05:09.248Z
+
+## Latest Codex Summary
+- None yet.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The CI guard only inspected `Insert Vector` in two workflows, so raw `{{ ... }}` interpolation in other memory-ingest Postgres nodes could ship undetected.
+- What changed: Added a focused regression test for the shell check, expanded `memory_ingest_workflow_check.sh` to inspect every Postgres node across the three covered memory-ingest workflows, and parameterized `Insert Facts` / `Insert Audit` in both main workflows plus `Insert Facts` / `Insert Vector` / `Insert Audit` in the cached workflow.
+- Current blocker: none
+- Next exact step: Stage the workflow, script, test, and journal changes and create a checkpoint commit on `codex/issue-108`.
+- Verification gap: Focused verification passed; broader lint/test suites have not been run in this turn.
+- Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; n8n/workflows/01_memory_ingest.json; n8n/workflows-v3/01_memory_ingest.json; n8n/workflows/01_memory_ingest_v3_cached.json; .codex-supervisor/issues/108/issue-journal.md
+- Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
+- Last focused command: python3 -m unittest -q tests/test_memory_ingest_workflow_check.py && bash scripts/ci/memory_ingest_workflow_check.sh
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -22,12 +22,12 @@
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The CI guard only inspected `Insert Vector` in two workflows, so raw `{{ ... }}` interpolation in other memory-ingest Postgres nodes could ship undetected.
-- What changed: Added a focused regression test for the shell check, expanded `memory_ingest_workflow_check.sh` to inspect every Postgres node across the three covered memory-ingest workflows, and parameterized `Insert Facts` / `Insert Audit` in both main workflows plus `Insert Facts` / `Insert Vector` / `Insert Audit` in the cached workflow.
+- What changed: Added a focused regression test for the shell check, expanded `memory_ingest_workflow_check.sh` to inspect every Postgres node across the three covered memory-ingest workflows, parameterized `Insert Facts` / `Insert Audit` in both main workflows plus `Insert Facts` / `Insert Vector` / `Insert Audit` in the cached workflow, committed the result as `def7764`, pushed `codex/issue-108`, and opened draft PR #110.
 - Current blocker: none
-- Next exact step: Stage the workflow, script, test, and journal changes and create a checkpoint commit on `codex/issue-108`.
+- Next exact step: Monitor PR #110 checks and address any CI or review feedback if it appears.
 - Verification gap: Focused verification passed; broader lint/test suites have not been run in this turn.
 - Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; n8n/workflows/01_memory_ingest.json; n8n/workflows-v3/01_memory_ingest.json; n8n/workflows/01_memory_ingest_v3_cached.json; .codex-supervisor/issues/108/issue-journal.md
 - Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
-- Last focused command: python3 -m unittest -q tests/test_memory_ingest_workflow_check.py && bash scripts/ci/memory_ingest_workflow_check.sh
+- Last focused command: gh pr create --draft --base main --head codex/issue-108 --title "Strengthen memory_ingest SQL interpolation guard" --body ...
 ### Scratchpad
 - Keep this section short. The supervisor may compact older notes automatically.

--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -6,46 +6,43 @@
 - Workspace: .
 - Journal: .codex-supervisor/issues/108/issue-journal.md
 - Current phase: addressing_review
-- Attempt count: 2 (implementation=1, repair=1)
-- Last head SHA: 27ed3ed0637a7e97672e6f41b1f3fae6da0ea109
+- Attempt count: 3 (implementation=1, repair=2)
+- Last head SHA: 996b396076979413de3832d7765d58422204aa88
 - Blocked reason: none
-- Last failure signature: PRRT_kwDORd-8zc56Tc8G|PRRT_kwDORd-8zc56Tc8K|PRRT_kwDORd-8zc56Tc8N|PRRT_kwDORd-8zc56Tc8O|PRRT_kwDORd-8zc56Tc8P|PRRT_kwDORd-8zc56Tc8R
+- Last failure signature: PRRT_kwDORd-8zc56Teyy|PRRT_kwDORd-8zc56Tey1
 - Repeated failure signature count: 1
-- Updated at: 2026-04-11T14:23:41.426Z
+- Updated at: 2026-04-11T14:33:10.811Z
 
 ## Latest Codex Summary
-Expanded `scripts/ci/memory_ingest_workflow_check.sh` to inspect every Postgres node in the covered memory-ingest workflows, fail on raw `{{ ... }}` or `${ ... }}` interpolation, require positional placeholders with `queryReplacement` when runtime values are bound, and report the exact workflow plus node on failure. I kept the stronger `Insert Vector` metadata contract for the two full memory-ingest workflows and added a focused regression test in [tests/test_memory_ingest_workflow_check.py](tests/test_memory_ingest_workflow_check.py).
+Validated the two remaining CodeRabbit findings against head `996b396` and confirmed both were still actionable in [scripts/ci/memory_ingest_workflow_check.sh](scripts/ci/memory_ingest_workflow_check.sh): `check_insert_vector_contract()` matched any node named `Insert Vector`, and the generic Postgres-node check only required `queryReplacement` presence instead of verifying bind coverage. The script now filters `Insert Vector` by Postgres node type and statically counts top-level `queryReplacement` array entries against the highest positional placeholder so under-bound parameter lists fail with the workflow path and node name.
 
-I also parameterized the remaining raw-SQL nodes in [n8n/workflows/01_memory_ingest.json](n8n/workflows/01_memory_ingest.json), [n8n/workflows-v3/01_memory_ingest.json](n8n/workflows-v3/01_memory_ingest.json), and [n8n/workflows/01_memory_ingest_v3_cached.json](n8n/workflows/01_memory_ingest_v3_cached.json) by replacing interpolated inserts with placeholder-based queries plus `queryReplacement`. The branch is pushed, and draft PR #110 is open: `https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110`.
+Extended [tests/test_memory_ingest_workflow_check.py](tests/test_memory_ingest_workflow_check.py) with regressions for both review threads: one proves a non-Postgres node named `Insert Vector` is ignored, and one proves a two-placeholder query with a one-item replacement array fails with the new binding-count error. Focused verification passed locally after the patch.
 
-Summary: Tightened the memory-ingest CI guard across all covered Postgres nodes, added a focused regression test, parameterized the remaining unsafe workflow SQL, pushed `codex/issue-108`, and opened draft PR #110.
-State hint: draft_pr
+Summary: Addressed the two remaining automated review threads by hardening the memory-ingest CI selector and bind-count validation.
+State hint: local_review_fix
 Blocked reason: none
 Tests: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`
-Next action: Monitor draft PR #110 checks and address any CI or review feedback if it appears.
-Failure signature: PRRT_kwDORd-8zc56Tc8G|PRRT_kwDORd-8zc56Tc8K|PRRT_kwDORd-8zc56Tc8N|PRRT_kwDORd-8zc56Tc8O|PRRT_kwDORd-8zc56Tc8P|PRRT_kwDORd-8zc56Tc8R
+Next action: Commit and push the review-fix checkpoint on `codex/issue-108`, then monitor PR #110 for refreshed CI/review state.
+Failure signature: none
 
 ## Active Failure Context
 - Category: review
-- Summary: 6 unresolved automated review thread(s) remain.
-- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144521
+- Summary: 2 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068153956
 - Details:
-  - .codex-supervisor/issues/108/issue-journal.md:10 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update supervisor status fields to current PR state** Line 8 and Line 10 look stale against the current tracking context (`waiting_ci` and he... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144521
-  - n8n/workflows-v3/01_memory_ingest.json:159 summary=_⚠️ Potential issue_ | _🟠 Major_ **Normalize invalid `confidence` values before building the array.** This mapping can still produce `NaN` for explicit-source facts with malfor... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144525
-  - n8n/workflows-v3/01_memory_ingest.json:257 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Use the canonical policy decision token in the fallback.** `Check Policy` emits `allow`, but this fallback writes `allowed`. url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144530
-  - n8n/workflows/01_memory_ingest_v3_cached.json:180 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard against `NaN` in the bound confidence array.** The explicit-source path can still pass malformed confidence values through, and this `N... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144531
-  - n8n/workflows/01_memory_ingest.json:121 summary=_⚠️ Potential issue_ | _🟠 Major_ **Harden `confidence` coercion before binding.** For `source === 'explicit'`, a fact with a non-numeric confidence can survive validation here,... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144533
+  - scripts/ci/memory_ingest_workflow_check.sh:50 summary=_⚠️ Potential issue_ | _🟠 Major_ **Filter `Insert Vector` by node type here too.** `check_insert_vector_contract()` currently selects every node named `Insert Vector`, while `c... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068153956
+  - scripts/ci/memory_ingest_workflow_check.sh:100 summary=_⚠️ Potential issue_ | _🟠 Major_ **Presence of `queryReplacement` is weaker than binding validation.** Once `queryReplacement` is non-null, this returns without checking that t... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068153961
 
 ## Codex Working Notes
 ### Current Handoff
-- Hypothesis: The CI guard only inspected `Insert Vector` in two workflows, so raw `{{ ... }}` interpolation in other memory-ingest Postgres nodes could ship undetected.
-- What changed: Applied the current PR review fixes on top of `def7764`, committed them as `c1ff3de`, and pushed `codex/issue-108`: hardened all three `Insert Facts` confidence arrays against `NaN`, changed the v3 audit fallback token from `allowed` to `allow`, tightened the CI `Insert Vector` contract to require an actual `.json.content_hash` bind, and extended the focused regression test to prove the stricter failure mode.
+- Hypothesis: The remaining review risk was not just missing workflow coverage; the CI guard could also inspect the wrong `Insert Vector` node by name and allow under-bound `queryReplacement` arrays to pass.
+- What changed: Tightened `check_insert_vector_contract()` to select only `n8n-nodes-base.postgres` nodes named `Insert Vector`, added static bind counting for parameterized `queryReplacement` array expressions, and extended the focused unit tests to cover both the selector hardening and the missing-binding failure mode.
 - Current blocker: none
-- Next exact step: Monitor PR #110 for updated CI and review state after `c1ff3de`, then address any remaining actionable threads if they appear.
-- Verification gap: Focused verification passed again; broader lint/test suites have still not been run in this turn.
-- Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; n8n/workflows/01_memory_ingest.json; n8n/workflows-v3/01_memory_ingest.json; n8n/workflows/01_memory_ingest_v3_cached.json; .codex-supervisor/issues/108/issue-journal.md
+- Next exact step: Push the current checkpoint and watch PR #110 for refreshed CI plus updated review-thread state.
+- Verification gap: Focused verification passed for the CI guard and its regression tests; broader repo-wide test/lint suites remain unrun in this turn.
+- Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; .codex-supervisor/issues/108/issue-journal.md
 - Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
-- Last focused command: `git push origin codex/issue-108`
+- Last focused command: `bash scripts/ci/memory_ingest_workflow_check.sh`
 ### Scratchpad
 - Local review triage: the stale issue-journal status comment is already obsolete in the live file; the actionable local fixes were PRRT_kwDORd-8zc56Tc8K, PRRT_kwDORd-8zc56Tc8N, PRRT_kwDORd-8zc56Tc8O, PRRT_kwDORd-8zc56Tc8P, and PRRT_kwDORd-8zc56Tc8R.
-- Commands run this turn: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`.
+- Commands run this turn: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`; `git diff -- scripts/ci/memory_ingest_workflow_check.sh tests/test_memory_ingest_workflow_check.py`.

--- a/.codex-supervisor/issues/108/issue-journal.md
+++ b/.codex-supervisor/issues/108/issue-journal.md
@@ -5,29 +5,47 @@
 - Branch: codex/issue-108
 - Workspace: .
 - Journal: .codex-supervisor/issues/108/issue-journal.md
-- Current phase: reproducing
-- Attempt count: 1 (implementation=1, repair=0)
-- Last head SHA: d6ac7291299d7ba3b1148c078cc07f74681d589c
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: 27ed3ed0637a7e97672e6f41b1f3fae6da0ea109
 - Blocked reason: none
-- Last failure signature: none
-- Repeated failure signature count: 0
-- Updated at: 2026-04-11T14:05:09.248Z
+- Last failure signature: PRRT_kwDORd-8zc56Tc8G|PRRT_kwDORd-8zc56Tc8K|PRRT_kwDORd-8zc56Tc8N|PRRT_kwDORd-8zc56Tc8O|PRRT_kwDORd-8zc56Tc8P|PRRT_kwDORd-8zc56Tc8R
+- Repeated failure signature count: 1
+- Updated at: 2026-04-11T14:23:41.426Z
 
 ## Latest Codex Summary
-- None yet.
+Expanded `scripts/ci/memory_ingest_workflow_check.sh` to inspect every Postgres node in the covered memory-ingest workflows, fail on raw `{{ ... }}` or `${ ... }}` interpolation, require positional placeholders with `queryReplacement` when runtime values are bound, and report the exact workflow plus node on failure. I kept the stronger `Insert Vector` metadata contract for the two full memory-ingest workflows and added a focused regression test in [tests/test_memory_ingest_workflow_check.py](tests/test_memory_ingest_workflow_check.py).
+
+I also parameterized the remaining raw-SQL nodes in [n8n/workflows/01_memory_ingest.json](n8n/workflows/01_memory_ingest.json), [n8n/workflows-v3/01_memory_ingest.json](n8n/workflows-v3/01_memory_ingest.json), and [n8n/workflows/01_memory_ingest_v3_cached.json](n8n/workflows/01_memory_ingest_v3_cached.json) by replacing interpolated inserts with placeholder-based queries plus `queryReplacement`. The branch is pushed, and draft PR #110 is open: `https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110`.
+
+Summary: Tightened the memory-ingest CI guard across all covered Postgres nodes, added a focused regression test, parameterized the remaining unsafe workflow SQL, pushed `codex/issue-108`, and opened draft PR #110.
+State hint: draft_pr
+Blocked reason: none
+Tests: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`
+Next action: Monitor draft PR #110 checks and address any CI or review feedback if it appears.
+Failure signature: PRRT_kwDORd-8zc56Tc8G|PRRT_kwDORd-8zc56Tc8K|PRRT_kwDORd-8zc56Tc8N|PRRT_kwDORd-8zc56Tc8O|PRRT_kwDORd-8zc56Tc8P|PRRT_kwDORd-8zc56Tc8R
 
 ## Active Failure Context
-- None recorded.
+- Category: review
+- Summary: 6 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144521
+- Details:
+  - .codex-supervisor/issues/108/issue-journal.md:10 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Update supervisor status fields to current PR state** Line 8 and Line 10 look stale against the current tracking context (`waiting_ci` and he... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144521
+  - n8n/workflows-v3/01_memory_ingest.json:159 summary=_⚠️ Potential issue_ | _🟠 Major_ **Normalize invalid `confidence` values before building the array.** This mapping can still produce `NaN` for explicit-source facts with malfor... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144525
+  - n8n/workflows-v3/01_memory_ingest.json:257 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Use the canonical policy decision token in the fallback.** `Check Policy` emits `allow`, but this fallback writes `allowed`. url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144530
+  - n8n/workflows/01_memory_ingest_v3_cached.json:180 summary=_⚠️ Potential issue_ | _🟠 Major_ **Guard against `NaN` in the bound confidence array.** The explicit-source path can still pass malformed confidence values through, and this `N... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144531
+  - n8n/workflows/01_memory_ingest.json:121 summary=_⚠️ Potential issue_ | _🟠 Major_ **Harden `confidence` coercion before binding.** For `source === 'explicit'`, a fact with a non-numeric confidence can survive validation here,... url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/110#discussion_r3068144533
 
 ## Codex Working Notes
 ### Current Handoff
 - Hypothesis: The CI guard only inspected `Insert Vector` in two workflows, so raw `{{ ... }}` interpolation in other memory-ingest Postgres nodes could ship undetected.
-- What changed: Added a focused regression test for the shell check, expanded `memory_ingest_workflow_check.sh` to inspect every Postgres node across the three covered memory-ingest workflows, parameterized `Insert Facts` / `Insert Audit` in both main workflows plus `Insert Facts` / `Insert Vector` / `Insert Audit` in the cached workflow, committed the result as `def7764`, pushed `codex/issue-108`, and opened draft PR #110.
+- What changed: Applied the current PR review fixes on top of `def7764`: hardened all three `Insert Facts` confidence arrays against `NaN`, changed the v3 audit fallback token from `allowed` to `allow`, tightened the CI `Insert Vector` contract to require an actual `.json.content_hash` bind, and extended the focused regression test to prove the stricter failure mode.
 - Current blocker: none
-- Next exact step: Monitor PR #110 checks and address any CI or review feedback if it appears.
-- Verification gap: Focused verification passed; broader lint/test suites have not been run in this turn.
+- Next exact step: Commit these review fixes on `codex/issue-108`, then push the branch and refresh PR #110 for another review/CI pass.
+- Verification gap: Focused verification passed again; broader lint/test suites have still not been run in this turn.
 - Files touched: scripts/ci/memory_ingest_workflow_check.sh; tests/test_memory_ingest_workflow_check.py; n8n/workflows/01_memory_ingest.json; n8n/workflows-v3/01_memory_ingest.json; n8n/workflows/01_memory_ingest_v3_cached.json; .codex-supervisor/issues/108/issue-journal.md
 - Rollback concern: The `Insert Facts` rewrite now depends on Postgres `unnest` with aligned arrays from n8n `queryReplacement`, so a rollback should keep the script and workflow SQL in sync.
-- Last focused command: gh pr create --draft --base main --head codex/issue-108 --title "Strengthen memory_ingest SQL interpolation guard" --body ...
+- Last focused command: `bash scripts/ci/memory_ingest_workflow_check.sh`
 ### Scratchpad
-- Keep this section short. The supervisor may compact older notes automatically.
+- Local review triage: the stale issue-journal status comment is already obsolete in the live file; the actionable local fixes were PRRT_kwDORd-8zc56Tc8K, PRRT_kwDORd-8zc56Tc8N, PRRT_kwDORd-8zc56Tc8O, PRRT_kwDORd-8zc56Tc8P, and PRRT_kwDORd-8zc56Tc8R.
+- Commands run this turn: `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`; `bash scripts/ci/memory_ingest_workflow_check.sh`.

--- a/n8n/workflows-v3/01_memory_ingest.json
+++ b/n8n/workflows-v3/01_memory_ingest.json
@@ -156,7 +156,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number.isFinite(Number(f.confidence)) ? Number(f.confidence) : 0)\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",
@@ -254,7 +254,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO audit_events (actor, action, target, decision, payload_jsonb, created_at)\nVALUES ($1, $2, $3, $4, $5::jsonb, NOW());",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  'workflow:memory_ingest',\n  'memory_write',\n  $input.first().json.scope,\n  $input.first().json.policy?.decision || 'allowed',\n  JSON.stringify({\n    request_id: $input.first().json.request_id || '',\n    policy: $input.first().json.policy || {}\n  })\n] }}"
+          "queryReplacement": "={{ [\n  'workflow:memory_ingest',\n  'memory_write',\n  $input.first().json.scope,\n  $input.first().json.policy?.decision || 'allow',\n  JSON.stringify({\n    request_id: $input.first().json.request_id || '',\n    policy: $input.first().json.policy || {}\n  })\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",

--- a/n8n/workflows-v3/01_memory_ingest.json
+++ b/n8n/workflows-v3/01_memory_ingest.json
@@ -154,8 +154,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nVALUES {{ $input.all()[0].json.facts.map(f => `('${f.subject.replace(/'/g, \"''\")}', '${f.predicate.replace(/'/g, \"''\")}', '${f.object.replace(/'/g, \"''\")}', ${f.confidence})`).join(',') }};",
-        "additionalFields": {}
+        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -250,8 +252,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO audit_events (actor, action, target, decision, payload_jsonb, created_at)\nVALUES ('workflow:memory_ingest', 'memory_write', '{{ $input.first().json.scope }}', '{{ $input.first().json.policy.decision || \"allowed\" }}', '{{ JSON.stringify({ request_id: $input.first().json.request_id || \"\", policy: $input.first().json.policy || {} }).replace(/'/g, \"''\") }}'::jsonb, NOW());",
-        "additionalFields": {}
+        "query": "INSERT INTO audit_events (actor, action, target, decision, payload_jsonb, created_at)\nVALUES ($1, $2, $3, $4, $5::jsonb, NOW());",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  'workflow:memory_ingest',\n  'memory_write',\n  $input.first().json.scope,\n  $input.first().json.policy?.decision || 'allowed',\n  JSON.stringify({\n    request_id: $input.first().json.request_id || '',\n    policy: $input.first().json.policy || {}\n  })\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows/01_memory_ingest.json
+++ b/n8n/workflows/01_memory_ingest.json
@@ -116,8 +116,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nVALUES {{ $input.all()[0].json.facts.map(f => `('${f.subject.replace(/'/g, \"''\")}', '${f.predicate.replace(/'/g, \"''\")}', '${f.object.replace(/'/g, \"''\")}', ${f.confidence})`).join(',') }};",
-        "additionalFields": {}
+        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -212,8 +214,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO audit_events (actor, action, target, decision, created_at)\nVALUES ('workflow:memory_ingest', 'memory_write', '{{ $input.first().json.scope }}', 'allowed', NOW());",
-        "additionalFields": {}
+        "query": "INSERT INTO audit_events (actor, action, target, decision, created_at)\nVALUES ($1, $2, $3, $4, NOW());",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  'workflow:memory_ingest',\n  'memory_write',\n  $input.first().json.scope,\n  'allowed'\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/n8n/workflows/01_memory_ingest.json
+++ b/n8n/workflows/01_memory_ingest.json
@@ -118,7 +118,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number.isFinite(Number(f.confidence)) ? Number(f.confidence) : 0)\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",

--- a/n8n/workflows/01_memory_ingest_v3_cached.json
+++ b/n8n/workflows/01_memory_ingest_v3_cached.json
@@ -177,7 +177,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number.isFinite(Number(f.confidence)) ? Number(f.confidence) : 0)\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",

--- a/n8n/workflows/01_memory_ingest_v3_cached.json
+++ b/n8n/workflows/01_memory_ingest_v3_cached.json
@@ -175,8 +175,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nVALUES {{ $input.all()[0].json.facts.map(f => `('${f.subject.replace(/'/g, \"''\")}', '${f.predicate.replace(/'/g, \"''\")}', '${f.object.replace(/'/g, \"''\")}', ${f.confidence})`).join(',') }};",
-        "additionalFields": {}
+        "query": "INSERT INTO memory_facts (subject, predicate, object, confidence)\nSELECT fact.subject, fact.predicate, fact.object, fact.confidence\nFROM unnest($1::text[], $2::text[], $3::text[], $4::double precision[]) AS fact(subject, predicate, object, confidence);",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  ($input.first().json.facts || []).map(f => String(f.subject || '')),\n  ($input.first().json.facts || []).map(f => String(f.predicate || '')),\n  ($input.first().json.facts || []).map(f => String(f.object || '')),\n  ($input.first().json.facts || []).map(f => Number(f.confidence || 0))\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -242,8 +244,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO memory_vectors (tenant_id, scope, content, embedding, content_hash, created_at)\nVALUES ('{{ $input.first().json.tenant_id }}', '{{ $input.first().json.scope }}', '{{ $input.first().json.text.replace(/'/g, \"''\") }}', '{{ $input.first().json.embedding }}'::vector, '{{ $input.first().json.content_hash }}', NOW());",
-        "additionalFields": {}
+        "query": "INSERT INTO memory_vectors (tenant_id, scope, content, embedding, content_hash, created_at)\nVALUES ($1, $2, $3, $4::vector, $5, NOW());",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  $input.first().json.tenant_id,\n  $input.first().json.scope,\n  $input.first().json.text,\n  $input.first().json.embedding,\n  $input.first().json.content_hash\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
@@ -262,8 +266,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO audit_events (actor, action, target, decision, created_at)\nVALUES ('workflow:memory_ingest', 'memory_write', '{{ $input.first().json.scope }}', 'allowed', NOW());",
-        "additionalFields": {}
+        "query": "INSERT INTO audit_events (actor, action, target, decision, created_at)\nVALUES ($1, $2, $3, $4, NOW());",
+        "additionalFields": {
+          "queryReplacement": "={{ [\n  'workflow:memory_ingest',\n  'memory_write',\n  $input.first().json.scope,\n  'allowed'\n] }}"
+        }
       },
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,

--- a/scripts/ci/memory_ingest_workflow_check.sh
+++ b/scripts/ci/memory_ingest_workflow_check.sh
@@ -62,7 +62,7 @@ check_insert_vector_contract() {
     fi
   done
 
-  if ! grep -Fq "content_hash" <<<"$query_replacement"; then
+  if ! grep -Fq '.json.content_hash' <<<"$query_replacement"; then
     die "Insert Vector queryReplacement in ${workflow_path} must preserve content_hash"
   fi
 }

--- a/scripts/ci/memory_ingest_workflow_check.sh
+++ b/scripts/ci/memory_ingest_workflow_check.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-required_patterns=(
+# Guardrail intent:
+# - inspect every Postgres node in the memory-ingest workflow family
+# - fail fast on raw template interpolation inside SQL text
+# - require positional placeholders plus queryReplacement when runtime values are bound
+# - allow constant SQL that does not accept runtime input
+
+covered_workflows=(
+  "n8n/workflows/01_memory_ingest.json"
+  "n8n/workflows-v3/01_memory_ingest.json"
+  "n8n/workflows/01_memory_ingest_v3_cached.json"
+)
+
+insert_vector_required_patterns=(
   "content_hash"
   "metadata_jsonb"
   "tags"
@@ -14,35 +26,106 @@ required_patterns=(
   '$3'
 )
 
-check_workflow() {
+die() {
+  echo "$1" >&2
+  exit 1
+}
+
+query_contains_raw_interpolation() {
+  local query="$1"
+  grep -Eq '\{\{|\$\{' <<<"$query"
+}
+
+query_has_positional_placeholders() {
+  local query="$1"
+  grep -Eq '\$[0-9]+' <<<"$query"
+}
+
+check_insert_vector_contract() {
   local workflow_path="$1"
   local query
   local query_replacement
+
   query="$(jq -r '.nodes[] | select(.name == "Insert Vector") | .parameters.query' "$workflow_path")"
   query_replacement="$(jq -r '.nodes[] | select(.name == "Insert Vector") | .parameters.additionalFields.queryReplacement' "$workflow_path")"
 
   if [[ -z "$query" || "$query" == "null" ]]; then
-    echo "Insert Vector query not found: ${workflow_path}" >&2
-    exit 1
+    die "Insert Vector query not found: ${workflow_path}"
   fi
   if [[ -z "$query_replacement" || "$query_replacement" == "null" ]]; then
-    echo "Insert Vector queryReplacement not found: ${workflow_path}" >&2
-    exit 1
+    die "Insert Vector queryReplacement not found: ${workflow_path}"
   fi
 
-  for pattern in "${required_patterns[@]}"; do
-    if ! grep -Fq "$pattern" <<< "$query"; then
-      echo "Missing '${pattern}' in ${workflow_path}" >&2
-      exit 1
+  for pattern in "${insert_vector_required_patterns[@]}"; do
+    if ! grep -Fq "$pattern" <<<"$query"; then
+      die "Insert Vector in ${workflow_path} is missing '${pattern}'"
     fi
   done
-  if ! grep -Fq "content_hash" <<< "$query_replacement"; then
-    echo "Missing 'content_hash' in queryReplacement for ${workflow_path}" >&2
-    exit 1
+
+  if ! grep -Fq "content_hash" <<<"$query_replacement"; then
+    die "Insert Vector queryReplacement in ${workflow_path} must preserve content_hash"
   fi
 }
 
-check_workflow "n8n/workflows/01_memory_ingest.json"
-check_workflow "n8n/workflows-v3/01_memory_ingest.json"
+check_postgres_node() {
+  local workflow_path="$1"
+  local node_name="$2"
+  local query
+  local query_replacement
+  local has_query_replacement="false"
+
+  query="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == $node_name) | .parameters.query' "$workflow_path")"
+  query_replacement="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == $node_name) | .parameters.additionalFields.queryReplacement' "$workflow_path")"
+
+  if [[ -z "$query" || "$query" == "null" ]]; then
+    die "Postgres node '${node_name}' is missing a query in ${workflow_path}"
+  fi
+
+  if [[ -n "$query_replacement" && "$query_replacement" != "null" ]]; then
+    has_query_replacement="true"
+  fi
+
+  if query_contains_raw_interpolation "$query"; then
+    die "Raw SQL interpolation detected in ${workflow_path} :: ${node_name}"
+  fi
+
+  if query_has_positional_placeholders "$query"; then
+    if [[ "$has_query_replacement" != "true" ]]; then
+      die "Parameterized SQL requires queryReplacement in ${workflow_path} :: ${node_name}"
+    fi
+    return
+  fi
+
+  if [[ "$has_query_replacement" == "true" ]]; then
+    die "queryReplacement without positional placeholders in ${workflow_path} :: ${node_name}"
+  fi
+}
+
+check_workflow() {
+  local workflow_path="$1"
+  local node_names_raw
+  local node_name
+
+  if [[ ! -f "$workflow_path" ]]; then
+    die "Workflow not found: ${workflow_path}"
+  fi
+
+  node_names_raw="$(jq -r '.nodes[] | select(.type == "n8n-nodes-base.postgres") | .name' "$workflow_path")"
+
+  if [[ -z "$node_names_raw" ]]; then
+    die "No Postgres nodes found in ${workflow_path}"
+  fi
+
+  while IFS= read -r node_name; do
+    check_postgres_node "$workflow_path" "$node_name"
+  done <<<"$node_names_raw"
+}
+
+for workflow_path in "${covered_workflows[@]}"; do
+  check_workflow "$workflow_path"
+done
+
+check_insert_vector_contract "n8n/workflows/01_memory_ingest.json"
+check_insert_vector_contract "n8n/workflows-v3/01_memory_ingest.json"
 
 echo "Memory ingest workflow metadata checks passed."

--- a/scripts/ci/memory_ingest_workflow_check.sh
+++ b/scripts/ci/memory_ingest_workflow_check.sh
@@ -41,13 +41,126 @@ query_has_positional_placeholders() {
   grep -Eq '\$[0-9]+' <<<"$query"
 }
 
+query_highest_positional_placeholder() {
+  local query="$1"
+  python3 - "$query" <<'PY'
+import re
+import sys
+
+query = sys.argv[1]
+placeholders = [int(match) for match in re.findall(r'\$(\d+)', query)]
+print(max(placeholders, default=0))
+PY
+}
+
+query_replacement_binding_count() {
+  local query_replacement="$1"
+  python3 - "$query_replacement" <<'PY'
+import sys
+
+expr = sys.argv[1].strip()
+if expr.startswith('={{') and expr.endswith('}}'):
+    expr = expr[3:-2].strip()
+
+if not expr.startswith('[') or not expr.endswith(']'):
+    print("unparseable")
+    raise SystemExit(0)
+
+body = expr[1:-1]
+depth = 0
+count = 0
+token_started = False
+in_single = False
+in_double = False
+in_backtick = False
+escape = False
+
+for ch in body:
+    if in_single:
+        token_started = True
+        if escape:
+            escape = False
+        elif ch == '\\':
+            escape = True
+        elif ch == "'":
+            in_single = False
+        continue
+
+    if in_double:
+        token_started = True
+        if escape:
+            escape = False
+        elif ch == '\\':
+            escape = True
+        elif ch == '"':
+            in_double = False
+        continue
+
+    if in_backtick:
+        token_started = True
+        if escape:
+            escape = False
+        elif ch == '\\':
+            escape = True
+        elif ch == '`':
+            in_backtick = False
+        continue
+
+    if ch == "'":
+        in_single = True
+        token_started = True
+        continue
+
+    if ch == '"':
+        in_double = True
+        token_started = True
+        continue
+
+    if ch == '`':
+        in_backtick = True
+        token_started = True
+        continue
+
+    if ch in '([{':
+        depth += 1
+        token_started = True
+        continue
+
+    if ch in ')]}':
+        if depth == 0:
+            print("unparseable")
+            raise SystemExit(0)
+        depth -= 1
+        token_started = True
+        continue
+
+    if ch == ',' and depth == 0:
+        if token_started:
+            count += 1
+            token_started = False
+        continue
+
+    if not ch.isspace():
+        token_started = True
+
+if in_single or in_double or in_backtick or depth != 0:
+    print("unparseable")
+    raise SystemExit(0)
+
+if token_started:
+    count += 1
+
+print(count)
+PY
+}
+
 check_insert_vector_contract() {
   local workflow_path="$1"
   local query
   local query_replacement
 
-  query="$(jq -r '.nodes[] | select(.name == "Insert Vector") | .parameters.query' "$workflow_path")"
-  query_replacement="$(jq -r '.nodes[] | select(.name == "Insert Vector") | .parameters.additionalFields.queryReplacement' "$workflow_path")"
+  query="$(jq -r '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == "Insert Vector") | .parameters.query' "$workflow_path")"
+  query_replacement="$(jq -r '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == "Insert Vector") | .parameters.additionalFields.queryReplacement' "$workflow_path")"
 
   if [[ -z "$query" || "$query" == "null" ]]; then
     die "Insert Vector query not found: ${workflow_path}"
@@ -73,6 +186,8 @@ check_postgres_node() {
   local query
   local query_replacement
   local has_query_replacement="false"
+  local highest_placeholder
+  local binding_count
 
   query="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == $node_name) | .parameters.query' "$workflow_path")"
   query_replacement="$(jq -r --arg node_name "$node_name" '.nodes[] | select(.type == "n8n-nodes-base.postgres" and .name == $node_name) | .parameters.additionalFields.queryReplacement' "$workflow_path")"
@@ -92,6 +207,14 @@ check_postgres_node() {
   if query_has_positional_placeholders "$query"; then
     if [[ "$has_query_replacement" != "true" ]]; then
       die "Parameterized SQL requires queryReplacement in ${workflow_path} :: ${node_name}"
+    fi
+    highest_placeholder="$(query_highest_positional_placeholder "$query")"
+    binding_count="$(query_replacement_binding_count "$query_replacement")"
+    if [[ ! "$binding_count" =~ ^[0-9]+$ ]]; then
+      die "queryReplacement must be a statically countable array expression in ${workflow_path} :: ${node_name}"
+    fi
+    if (( binding_count < highest_placeholder )); then
+      die "queryReplacement only provides ${binding_count} bindings for ${highest_placeholder} positional placeholders in ${workflow_path} :: ${node_name}"
     fi
     return
   fi

--- a/tests/test_memory_ingest_workflow_check.py
+++ b/tests/test_memory_ingest_workflow_check.py
@@ -60,8 +60,11 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
         }
 
     def _run_check(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
+        bash_path = shutil.which("bash")
+        if bash_path is None:
+            self.fail("bash executable not found in PATH")
         return subprocess.run(
-            ["bash", "scripts/ci/memory_ingest_workflow_check.sh"],
+            [bash_path, "scripts/ci/memory_ingest_workflow_check.sh"],
             cwd=repo_root,
             capture_output=True,
             text=True,

--- a/tests/test_memory_ingest_workflow_check.py
+++ b/tests/test_memory_ingest_workflow_check.py
@@ -1,0 +1,222 @@
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from typing import Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "memory_ingest_workflow_check.sh"
+
+
+class MemoryIngestWorkflowCheckTests(unittest.TestCase):
+    maxDiff = None
+
+    def _make_temp_repo(self) -> Path:
+        tmpdir = Path(tempfile.mkdtemp(prefix="memory-ingest-workflow-check-"))
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        (tmpdir / "scripts" / "ci").mkdir(parents=True)
+        (tmpdir / "n8n" / "workflows").mkdir(parents=True)
+        (tmpdir / "n8n" / "workflows-v3").mkdir(parents=True)
+        (tmpdir / "scripts" / "ci" / "memory_ingest_workflow_check.sh").write_text(
+            SCRIPT_PATH.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        return tmpdir
+
+    def _write_workflow(self, repo_root: Path, relative_path: str, nodes: list[dict]) -> None:
+        workflow_path = repo_root / relative_path
+        workflow_path.write_text(
+            __import__("json").dumps({"nodes": nodes}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def _postgres_node(
+        self,
+        name: str,
+        query: str,
+        query_replacement: Optional[str] = None,
+    ) -> dict:
+        node = {
+            "name": name,
+            "type": "n8n-nodes-base.postgres",
+            "parameters": {
+                "query": query,
+            },
+        }
+        if query_replacement is not None:
+            node["parameters"]["additionalFields"] = {
+                "queryReplacement": query_replacement,
+            }
+        return node
+
+    def _run_check(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "scripts/ci/memory_ingest_workflow_check.sh"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_check_fails_for_interpolated_non_insert_vector_postgres_node(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        safe_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Facts", "INSERT INTO memory_facts (subject) VALUES ($1);", "={{ ['value'] }}"),
+                self._postgres_node(
+                    "Insert Audit",
+                    "INSERT INTO audit_events (target) VALUES ('{{ $json.scope }}');",
+                ),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("n8n/workflows-v3/01_memory_ingest.json", result.stderr)
+        self.assertIn("Insert Audit", result.stderr)
+
+    def test_check_passes_for_parameterized_runtime_queries_and_constant_sql(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        safe_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+        safe_facts_query = (
+            "INSERT INTO memory_facts (subject, predicate, object, confidence) "
+            "VALUES ($1, $2, $3, $4);"
+        )
+        safe_audit_query = (
+            "INSERT INTO audit_events (actor, action, target, decision, payload_jsonb, created_at) "
+            "VALUES ($1, $2, $3, $4, $5::jsonb, NOW());"
+        )
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+                self._postgres_node("Health Check", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+                self._postgres_node("Static Bootstrap", "SELECT NOW();"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("Memory ingest workflow metadata checks passed.", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_ingest_workflow_check.py
+++ b/tests/test_memory_ingest_workflow_check.py
@@ -98,7 +98,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             RETURNING id, content_hash;
             """
         ).strip()
-        safe_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+        safe_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', $input.first().json.content_hash, '{}'] }}"
 
         self._write_workflow(
             repo_root,
@@ -172,7 +172,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             RETURNING id, content_hash;
             """
         ).strip()
-        safe_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+        safe_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', $input.first().json.content_hash, '{}'] }}"
         safe_facts_query = (
             "INSERT INTO memory_facts (subject, predicate, object, confidence) "
             "VALUES ($1, $2, $3, $4);"
@@ -188,7 +188,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             [
                 self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
                 self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
-                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allow', '{}'] }}"),
                 self._postgres_node("Health Check", "SELECT 1;"),
             ],
         )
@@ -198,7 +198,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             [
                 self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
                 self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
-                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allow', '{}'] }}"),
             ],
         )
         self._write_workflow(
@@ -207,7 +207,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             [
                 self._postgres_node("Insert Facts", safe_facts_query, "={{ ['s', 'p', 'o', 0.9] }}"),
                 self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
-                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allowed', '{}'] }}"),
+                self._postgres_node("Insert Audit", safe_audit_query, "={{ ['actor', 'action', 'target', 'allow', '{}'] }}"),
                 self._postgres_node("Static Bootstrap", "SELECT NOW();"),
             ],
         )
@@ -216,6 +216,78 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("Memory ingest workflow metadata checks passed.", result.stdout)
+
+    def test_check_fails_when_insert_vector_replacement_mentions_content_hash_without_binding_it(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        loose_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, loose_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, loose_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, loose_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "Insert Vector queryReplacement in n8n/workflows/01_memory_ingest.json must preserve content_hash",
+            result.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_ingest_workflow_check.py
+++ b/tests/test_memory_ingest_workflow_check.py
@@ -52,6 +52,13 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             }
         return node
 
+    def _node(self, name: str, node_type: str, parameters: Optional[dict] = None) -> dict:
+        return {
+            "name": name,
+            "type": node_type,
+            "parameters": parameters or {},
+        }
+
     def _run_check(self, repo_root: Path) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["bash", "scripts/ci/memory_ingest_workflow_check.sh"],
@@ -254,7 +261,7 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             RETURNING id, content_hash;
             """
         ).strip()
-        loose_vector_replacement = "={{ { content_hash: 'hash', values: ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] } }}"
+        loose_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', 'hash', '{}'] }}"
 
         self._write_workflow(
             repo_root,
@@ -288,6 +295,149 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
             "Insert Vector queryReplacement in n8n/workflows/01_memory_ingest.json must preserve content_hash",
             result.stderr,
         )
+
+    def test_check_fails_when_query_replacement_has_fewer_bindings_than_placeholders(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        safe_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', $input.first().json.content_hash, '{}'] }}"
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Facts", "INSERT INTO memory_facts (subject, predicate) VALUES ($1, $2);", "={{ ['only-one'] }}"),
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "queryReplacement only provides 1 bindings for 2 positional placeholders in n8n/workflows/01_memory_ingest.json :: Insert Facts",
+            result.stderr,
+        )
+
+    def test_check_ignores_non_postgres_nodes_named_insert_vector(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        safe_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', $input.first().json.content_hash, '{}'] }}"
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._node("Insert Vector", "n8n-nodes-base.code", {"jsCode": "return [{ json: { ignored: true } }];"}),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("Memory ingest workflow metadata checks passed.", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- inspect every Postgres node in the memory-ingest workflow family in `scripts/ci/memory_ingest_workflow_check.sh`
- fail with workflow and node names when raw SQL interpolation or missing parameter binding is detected
- parameterize the remaining `Insert Facts`, `Insert Vector`, and `Insert Audit` queries in covered memory-ingest workflows

## Verification
- `python3 -m unittest -q tests/test_memory_ingest_workflow_check.py`
- `bash scripts/ci/memory_ingest_workflow_check.sh`

Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end CI tests that exercise workflow validation across multiple workflow variants, covering success and failure scenarios for parameter bindings.

* **Chores**
  * Updated workflows to use parameterized queries with structured bindings instead of inline interpolation.
  * Hardened CI checks to scan all relevant workflows, enforce placeholder↔replacement contracts, and report failing workflow/node details.

* **Documentation**
  * Added a supervisor journal capturing snapshot, status updates, and review notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->