### PR TITLE
[codex] Parameterize remaining memory_ingest SQL writes and audit inserts

### DIFF
--- a/n8n/workflows/01_memory_ingest_v3_cached.json
+++ b/n8n/workflows/01_memory_ingest_v3_cached.json
@@ -78,7 +78,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validate input\nconst input = $input.first().json.body;\n\nif (!input.tenant_id || !input.scope || !input.text) {\n  return [{\n    json: {\n      error: 'Missing required fields: tenant_id, scope, text'\n    }\n  }];\n}\n\n// Secret patterns to reject\nconst secretPatterns = [\n  /api[_-]?key/i,\n  /bearer\\s+[A-Za-z0-9-_.]+/i,\n  /-----BEGIN(.*?)PRIVATE KEY-----/i\n];\n\n// Check for secrets in text\nif (secretPatterns.some(p => p.test(input.text))) {\n  return [{\n    json: {\n      error: 'Rejected: potential secret detected in text'\n    }\n  }];\n}\n\n// Filter facts - only keep those with confidence >= 0.75 OR source == explicit\nconst filteredFacts = (input.facts || []).filter(f => {\n  // Check for secrets in fact fields\n  const factText = `${f.subject || ''} ${f.predicate || ''} ${f.object || ''}`;\n  if (secretPatterns.some(p => p.test(factText))) {\n    return false;\n  }\n  \n  // Apply commit rules\n  if (f.confidence >= 0.75 || input.source === 'explicit') {\n    // Reject if subject/predicate/object empty\n    if (!f.subject || !f.predicate || !f.object) {\n    return false;\n    }\n    return true;\n  }\n  return false;\n});\n\nreturn [{\n  json: {\n    tenant_id: input.tenant_id,\n    scope: input.scope,\n    text: input.text,\n    facts: filteredFacts,\n    source: input.source || 'unknown',\n    tags: input.tags || []\n  }\n}];"
+        "jsCode": "const crypto = require('crypto');\n\n// Validate input\nconst input = $input.first().json.body;\nconst normalizedText = String(input?.text || '').trim();\n\nif (!input?.tenant_id || !input?.scope || !normalizedText) {\n  return [{\n    json: {\n      error: 'Missing required fields: tenant_id, scope, text'\n    }\n  }];\n}\n\n// Secret patterns to reject\nconst secretPatterns = [\n  /api[_-]?key/i,\n  /bearer\\s+[A-Za-z0-9-_.]+/i,\n  /-----BEGIN(.*?)PRIVATE KEY-----/i\n];\n\n// Check for secrets in text\nif (secretPatterns.some((p) => p.test(normalizedText))) {\n  return [{\n    json: {\n      error: 'Rejected: potential secret detected in text'\n    }\n  }];\n}\n\n// Filter facts - only keep those with confidence >= 0.75 OR source == explicit\nconst filteredFacts = (input.facts || []).filter((f) => {\n  // Check for secrets in fact fields\n  const factText = `${f.subject || ''} ${f.predicate || ''} ${f.object || ''}`;\n  if (secretPatterns.some((p) => p.test(factText))) {\n    return false;\n  }\n\n  // Apply commit rules\n  if (f.confidence >= 0.75 || input.source === 'explicit') {\n    // Reject if subject/predicate/object empty\n    if (!f.subject || !f.predicate || !f.object) {\n      return false;\n    }\n    return true;\n  }\n  return false;\n});\n\nconst requestId = input.request_id || `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;\nconst source = String(input.source || 'unknown');\nconst tags = Array.isArray(input.tags) ? input.tags : [];\nconst metadata = (input.metadata && typeof input.metadata === 'object' && !Array.isArray(input.metadata))\n  ? input.metadata\n  : {};\nconst contentHash = crypto.createHash('sha256').update(normalizedText, 'utf8').digest('hex');\n\nreturn [{\n  json: {\n    tenant_id: input.tenant_id,\n    scope: input.scope,\n    text: normalizedText,\n    facts: filteredFacts,\n    source,\n    tags,\n    metadata,\n    request_id: requestId,\n    content_hash: contentHash\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 1,
@@ -115,7 +115,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Compute SHA256 hash of content for caching\nconst data = $input.first().json;\nconst crypto = require('crypto');\nconst contentHash = crypto.createHash('sha256').update(data.text).digest('hex');\n\nreturn [{\n  json: {\n    ...data,\n    content_hash: contentHash\n  }\n}];"
+        "jsCode": "// Preserve the validated payload shape for cache lookup.\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    ...data,\n    content_hash: data.content_hash || null\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 1,
@@ -244,9 +244,9 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO memory_vectors (tenant_id, scope, content, embedding, content_hash, created_at)\nVALUES ($1, $2, $3, $4::vector, $5, NOW());",
+        "query": "INSERT INTO memory_vectors (\n  tenant_id,\n  scope,\n  content,\n  embedding,\n  tags,\n  source,\n  content_hash,\n  metadata_jsonb,\n  created_at\n)\nVALUES (\n  $1,\n  $2,\n  $3,\n  $4::vector,\n  $5::jsonb,\n  $6,\n  $7,\n  $8::jsonb,\n  NOW()\n)\nON CONFLICT (tenant_id, scope, content_hash)\nWHERE content_hash IS NOT NULL\nDO UPDATE SET\n  content = EXCLUDED.content,\n  embedding = EXCLUDED.embedding,\n  tags = EXCLUDED.tags,\n  source = EXCLUDED.source,\n  metadata_jsonb = EXCLUDED.metadata_jsonb\nRETURNING id, content_hash;",
         "additionalFields": {
-          "queryReplacement": "={{ [\n  $input.first().json.tenant_id,\n  $input.first().json.scope,\n  $input.first().json.text,\n  $input.first().json.embedding,\n  $input.first().json.content_hash\n] }}"
+          "queryReplacement": "={{ [\n  $input.first().json.tenant_id,\n  $input.first().json.scope,\n  $input.first().json.text,\n  $input.first().json.embedding,\n  JSON.stringify($input.first().json.tags || []),\n  String($input.first().json.source || 'unknown'),\n  $input.first().json.content_hash,\n  JSON.stringify({\n    request_id: $input.first().json.request_id || null,\n    source: $input.first().json.source || 'unknown',\n    tags: $input.first().json.tags || [],\n    facts_count: Array.isArray($input.first().json.facts) ? $input.first().json.facts.length : 0,\n    metadata: $input.first().json.metadata || {},\n    policy: $input.first().json.policy || {}\n  })\n] }}"
         }
       },
       "type": "n8n-nodes-base.postgres",
@@ -265,6 +265,18 @@
     },
     {
       "parameters": {
+        "jsCode": "// Merge Insert Vector result with original data\nconst insertResult = $input.first().json;\nconst original = $('Parse Embedding').first().json;\nconst row = Array.isArray(insertResult) ? insertResult[0] : insertResult;\n\nreturn [{\n  json: {\n    ...original,\n    id: row?.id || null,\n    content_hash: row?.content_hash || original.content_hash || null\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 1,
+      "position": [
+        2250,
+        500
+      ],
+      "name": "Prepare Response"
+    },
+    {
+      "parameters": {
         "operation": "executeQuery",
         "query": "INSERT INTO audit_events (actor, action, target, decision, created_at)\nVALUES ($1, $2, $3, $4, NOW());",
         "additionalFields": {
@@ -274,7 +286,7 @@
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2,
       "position": [
-        2250,
+        2450,
         500
       ],
       "name": "Insert Audit",
@@ -293,7 +305,7 @@
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
       "position": [
-        2450,
+        2650,
         500
       ],
       "name": "Success Response"
@@ -410,6 +422,17 @@
       ]
     },
     "Insert Vector": {
+      "main": [
+        [
+          {
+            "node": "Prepare Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Response": {
       "main": [
         [
           {

--- a/scripts/ci/memory_ingest_workflow_check.sh
+++ b/scripts/ci/memory_ingest_workflow_check.sh
@@ -250,5 +250,6 @@ done
 
 check_insert_vector_contract "n8n/workflows/01_memory_ingest.json"
 check_insert_vector_contract "n8n/workflows-v3/01_memory_ingest.json"
+check_insert_vector_contract "n8n/workflows/01_memory_ingest_v3_cached.json"
 
 echo "Memory ingest workflow metadata checks passed."

--- a/tests/test_memory_ingest_workflow_check.py
+++ b/tests/test_memory_ingest_workflow_check.py
@@ -442,6 +442,84 @@ class MemoryIngestWorkflowCheckTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertIn("Memory ingest workflow metadata checks passed.", result.stdout)
 
+    def test_check_fails_when_cached_insert_vector_uses_legacy_insert_shape(self):
+        repo_root = self._make_temp_repo()
+        safe_vector_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (
+              tenant_id,
+              scope,
+              content,
+              embedding,
+              tags,
+              source,
+              content_hash,
+              metadata_jsonb,
+              created_at
+            )
+            VALUES (
+              $1,
+              $2,
+              $3,
+              $4::vector,
+              $5::jsonb,
+              $6,
+              $7,
+              $8::jsonb,
+              NOW()
+            )
+            ON CONFLICT (tenant_id, scope, content_hash)
+            WHERE content_hash IS NOT NULL
+            DO UPDATE SET
+              content = EXCLUDED.content,
+              embedding = EXCLUDED.embedding,
+              tags = EXCLUDED.tags,
+              source = EXCLUDED.source,
+              metadata_jsonb = EXCLUDED.metadata_jsonb
+            RETURNING id, content_hash;
+            """
+        ).strip()
+        safe_vector_replacement = "={{ ['tenant', 'scope', 'text', 'embedding', '[]', 'api', $input.first().json.content_hash, '{}'] }}"
+        legacy_cached_query = textwrap.dedent(
+            """
+            INSERT INTO memory_vectors (tenant_id, scope, content, embedding, content_hash, created_at)
+            VALUES ($1, $2, $3, $4::vector, $5, NOW());
+            """
+        ).strip()
+
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/01_memory_ingest.json",
+            [
+                self._postgres_node("Insert Vector", safe_vector_query, safe_vector_replacement),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows/01_memory_ingest_v3_cached.json",
+            [
+                self._postgres_node("Insert Vector", legacy_cached_query, "={{ ['tenant', 'scope', 'text', 'embedding', $input.first().json.content_hash] }}"),
+                self._postgres_node("Insert Audit", "SELECT 1;"),
+            ],
+        )
+
+        result = self._run_check(repo_root)
+
+        self.assertNotEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn(
+            "Insert Vector in n8n/workflows/01_memory_ingest_v3_cached.json is missing 'metadata_jsonb'",
+            result.stderr,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- harden the cached memory-ingest workflow `Insert Vector` node to match the parameterized upsert contract used by the other memory-ingest variants
- extend the memory-ingest CI guard so `n8n/workflows/01_memory_ingest_v3_cached.json` is covered by the same `Insert Vector` contract checks
- add regression coverage for the cached workflow guard hole so the previous raw/legacy shape would fail locally

## Why
The follow-up hardening pass for issue #109 found that the cached memory-ingest workflow was still on an older vector-write contract and the guard from #108 did not cover that path. This left a gap in the repo's "no raw SQL interpolation" invariant for memory-ingest workflows.

## Impact
- keeps memory vector upsert behavior aligned across all covered memory-ingest workflows
- preserves `content_hash` propagation in the cached path
- makes silent regressions in the cached workflow fail the memory-ingest guard

## Verification
- `python3 -m unittest -q tests.test_memory_ingest_workflow_check`
- `bash scripts/ci/memory_ingest_workflow_check.sh`
- `bash scripts/ci/build.sh`
- `bash scripts/ci/n8n_import_test.sh` (fails locally because Docker/Colima is unavailable: `dial unix /Users/jp.infra/.colima/default/docker.sock: connect: no such file or directory`)

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data validation and normalization in memory ingestion processes to improve data integrity.
  * Strengthened database conflict handling and consistency checks across workflow configurations.
  * Expanded CI test coverage to ensure workflow configuration compliance and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->