### PR TITLE
[codex] Enforce tenant context before executor policy evaluation

### DIFF
--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -890,13 +890,20 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         files = self._optional_string_map_field(body, 'files')
 
         session = session_manager.get_session(session_id)
-        scope = ""
-        tenant_id = ""
-        template = ""
-        if session:
-            scope = str(session.metadata.get("scope", ""))
-            tenant_id = str(session.metadata.get("tenant_id", ""))
-            template = session.template
+        if session is None:
+            self._send_json_response(
+                {
+                    "status": "error",
+                    "error": f"Session {session_id} not found or expired",
+                    "request_id": self.request_id,
+                },
+                404,
+            )
+            return
+
+        scope = str(session.metadata.get("scope", ""))
+        tenant_id = str(session.metadata.get("tenant_id", ""))
+        template = session.template
         policy_result = self._evaluate_policy(
             action="executor.session.execute",
             subject={

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -901,8 +901,8 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             )
             return
 
-        scope = str(session.metadata.get("scope", ""))
-        tenant_id = str(session.metadata.get("tenant_id", ""))
+        scope = session.metadata.get("scope")
+        tenant_id = session.metadata.get("tenant_id")
         template = session.template
         policy_result = self._evaluate_policy(
             action="executor.session.execute",

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -557,6 +557,56 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             return
         getattr(self, handler_name)(body)
 
+    def _validate_execution_tenancy_context(
+        self,
+        action: str,
+        subject: Dict[str, Any],
+        resource: Dict[str, Any],
+    ) -> None:
+        protected_actions = {
+            "executor.execute",
+            "executor.session.create",
+            "executor.session.execute",
+        }
+        if action not in protected_actions:
+            return
+
+        required_pairs = (
+            ("subject", "tenant_id"),
+            ("subject", "scope"),
+            ("resource", "tenant_id"),
+            ("resource", "scope"),
+        )
+        containers = {"subject": subject, "resource": resource}
+        missing = []
+        for container_name, field in required_pairs:
+            raw_value = containers[container_name].get(field)
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                missing.append(f"{container_name}.{field}")
+
+        if missing:
+            joined = ", ".join(missing)
+            raise RequestValidationError(
+                f"Invalid tenancy context for {action}: missing required fields {joined}",
+                status=403,
+            )
+
+        subject_tenant_id = str(subject["tenant_id"]).strip()
+        resource_tenant_id = str(resource["tenant_id"]).strip()
+        if subject_tenant_id != resource_tenant_id:
+            raise RequestValidationError(
+                f"Invalid tenancy context for {action}: tenant_id mismatch",
+                status=403,
+            )
+
+        subject_scope = str(subject["scope"]).strip()
+        resource_scope = str(resource["scope"]).strip()
+        if subject_scope != resource_scope:
+            raise RequestValidationError(
+                f"Invalid tenancy context for {action}: scope mismatch",
+                status=403,
+            )
+
     def _handle_get_root(self):
         self._send_json_response({
             "status": "success",
@@ -632,6 +682,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         resource: Dict[str, Any],
         context: Dict[str, Any]
     ) -> Dict[str, Any]:
+        self._validate_execution_tenancy_context(action, subject, resource)
         policy_input = {
             "subject": subject,
             "resource": resource,

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -258,6 +258,61 @@ def test_session_execute_denies_when_session_tenancy_metadata_is_missing():
         manager.stop()
 
 
+def test_session_execute_denies_when_session_tenancy_metadata_is_not_string():
+    manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
+    try:
+        with patch("executor.api_server.API_KEY", None), patch(
+            "executor.api_server.session_manager", manager
+        ), patch(
+            "executor.session.CodeSandbox", _FakeSandbox
+        ), patch(
+            "executor.api_server.policy_client.evaluate",
+            return_value={
+                "decision": "allow",
+                "allow": True,
+                "requires_approval": False,
+                "risk_score": 0,
+                "reasons": [],
+            },
+        ) as evaluate_mock, patch(
+            "executor.api_server.policy_client.enforce", return_value=True
+        ), patch(
+            "executor.api_server.session_manager.execute_in_session",
+            return_value={
+                "status": "success",
+                "exit_code": 0,
+                "stdout": "session-ok",
+                "stderr": "",
+                "language": "python",
+            },
+        ) as execute_mock:
+            session_id = manager.create_session(
+                template="default",
+                ttl=120,
+                metadata={"tenant_id": {"nested": "t1"}, "scope": ["analysis"]},
+            )
+
+            server, thread = _start_server()
+            try:
+                status, payload = _post_json(
+                    server.server_port,
+                    "/session/execute",
+                    {"session_id": session_id, "code": "print('ok')", "language": "python"},
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+        assert status == 403
+        assert payload["status"] == "error"
+        assert "invalid tenancy context" in payload["error"].lower()
+        execute_mock.assert_not_called()
+        evaluate_mock.assert_not_called()
+    finally:
+        manager.stop()
+
+
 def test_session_manager_persists_ttl_state_with_store():
     state_store = _FakeStateStore()
     manager = SessionManager(

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -207,6 +207,57 @@ def test_session_execute_rejects_invalid_files_map_before_side_effects():
         manager.stop()
 
 
+def test_session_execute_denies_when_session_tenancy_metadata_is_missing():
+    manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
+    try:
+        with patch("executor.api_server.API_KEY", None), patch(
+            "executor.api_server.session_manager", manager
+        ), patch(
+            "executor.session.CodeSandbox", _FakeSandbox
+        ), patch(
+            "executor.api_server.policy_client.evaluate",
+            return_value={
+                "decision": "allow",
+                "allow": True,
+                "requires_approval": False,
+                "risk_score": 0,
+                "reasons": [],
+            },
+        ) as evaluate_mock, patch(
+            "executor.api_server.policy_client.enforce", return_value=True
+        ), patch(
+            "executor.api_server.session_manager.execute_in_session",
+            return_value={
+                "status": "success",
+                "exit_code": 0,
+                "stdout": "session-ok",
+                "stderr": "",
+                "language": "python",
+            },
+        ) as execute_mock:
+            session_id = manager.create_session(template="default", ttl=120, metadata={})
+
+            server, thread = _start_server()
+            try:
+                status, payload = _post_json(
+                    server.server_port,
+                    "/session/execute",
+                    {"session_id": session_id, "code": "print('ok')", "language": "python"},
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+        assert status == 403
+        assert payload["status"] == "error"
+        assert "tenant" in payload["error"].lower()
+        execute_mock.assert_not_called()
+        evaluate_mock.assert_not_called()
+    finally:
+        manager.stop()
+
+
 def test_session_manager_persists_ttl_state_with_store():
     state_store = _FakeStateStore()
     manager = SessionManager(

--- a/policy/opa/authz.rego
+++ b/policy/opa/authz.rego
@@ -37,14 +37,19 @@ protected_action if input.action == "executor.execute"
 protected_action if input.action == "executor.session.create"
 protected_action if input.action == "executor.session.execute"
 
-missing_tenancy_field(container, field) if {
-	value := object.get(container, field, "")
-	not is_string(value)
+tenancy_string(container, field) := value if {
+	raw := object.get(container, field, "")
+	is_string(raw)
+	value := trim(raw, " \t\r\n")
+}
+
+tenancy_string(container, field) := "" if {
+	raw := object.get(container, field, "")
+	not is_string(raw)
 }
 
 missing_tenancy_field(container, field) if {
-	value := trim(object.get(container, field, ""))
-	value == ""
+	tenancy_string(container, field) == ""
 }
 
 deny_missing_tenancy if {
@@ -61,8 +66,8 @@ deny_missing_tenancy if {
 
 deny_tenant_mismatch if {
 	protected_action
-	subject_tenant_id := trim(object.get(input.subject, "tenant_id", ""))
-	resource_tenant_id := trim(object.get(input.resource, "tenant_id", ""))
+	subject_tenant_id := tenancy_string(input.subject, "tenant_id")
+	resource_tenant_id := tenancy_string(input.resource, "tenant_id")
 	subject_tenant_id != ""
 	resource_tenant_id != ""
 	subject_tenant_id != resource_tenant_id

--- a/policy/opa/authz.rego
+++ b/policy/opa/authz.rego
@@ -16,6 +16,8 @@ decision := "deny" if {
 }
 
 allow if {
+	not deny_missing_tenancy
+	not deny_tenant_mismatch
 	not deny_task_type
 	not deny_scope_mismatch
 	not deny_network
@@ -24,10 +26,47 @@ allow if {
 
 requires_approval if approval_high_risk
 
+deny_reasons contains "missing_tenancy" if deny_missing_tenancy
+deny_reasons contains "tenant_mismatch" if deny_tenant_mismatch
 deny_reasons contains "task_type_not_allowed" if deny_task_type
 deny_reasons contains "scope_mismatch" if deny_scope_mismatch
 deny_reasons contains "network_not_allowed" if deny_network
 deny_reasons contains "high_risk_requires_approval" if approval_high_risk
+
+protected_action if input.action == "executor.execute"
+protected_action if input.action == "executor.session.create"
+protected_action if input.action == "executor.session.execute"
+
+missing_tenancy_field(container, field) if {
+	value := object.get(container, field, "")
+	not is_string(value)
+}
+
+missing_tenancy_field(container, field) if {
+	value := trim(object.get(container, field, ""))
+	value == ""
+}
+
+deny_missing_tenancy if {
+	protected_action
+	some field in ["tenant_id", "scope"]
+	missing_tenancy_field(input.subject, field)
+}
+
+deny_missing_tenancy if {
+	protected_action
+	some field in ["tenant_id", "scope"]
+	missing_tenancy_field(input.resource, field)
+}
+
+deny_tenant_mismatch if {
+	protected_action
+	subject_tenant_id := trim(object.get(input.subject, "tenant_id", ""))
+	resource_tenant_id := trim(object.get(input.resource, "tenant_id", ""))
+	subject_tenant_id != ""
+	resource_tenant_id != ""
+	subject_tenant_id != resource_tenant_id
+}
 
 deny_task_type if {
 	input.action == "executor.execute"

--- a/policy/opa/authz_test.rego
+++ b/policy/opa/authz_test.rego
@@ -42,6 +42,32 @@ test_authz_deny_scope_mismatch if {
 	result.reasons == ["scope_mismatch"]
 }
 
+test_authz_deny_missing_tenancy if {
+	result := data.ai.policy.result with input as {
+		"subject": {"tenant_id": "t1", "scope": "analysis", "role": "api"},
+		"resource": {"tenant_id": "t1", "task_type": "code_execution"},
+		"action": "executor.execute",
+		"context": {"network_enabled": false},
+	} with data.ai.policy.risk_score as 0
+	result.decision == "deny"
+	not result.allow
+	result.risk_score == 0
+	result.reasons == ["missing_tenancy"]
+}
+
+test_authz_deny_tenant_mismatch if {
+	result := data.ai.policy.result with input as {
+		"subject": {"tenant_id": "t1", "scope": "analysis", "role": "api"},
+		"resource": {"tenant_id": "t2", "scope": "analysis", "task_type": "code_execution"},
+		"action": "executor.execute",
+		"context": {"network_enabled": false},
+	} with data.ai.policy.risk_score as 0
+	result.decision == "deny"
+	not result.allow
+	result.risk_score == 0
+	result.reasons == ["tenant_mismatch"]
+}
+
 test_authz_deny_network_not_allowed if {
 	result := data.ai.policy.result with input as {
 		"subject": {"tenant_id": "t1", "scope": "analysis", "role": "api"},


### PR DESCRIPTION
## Summary
- fail closed when protected executor actions are missing tenancy metadata or carry mismatched tenancy context
- reject session execution before policy evaluation when stored session metadata lacks `tenant_id` or `scope`
- add OPA authz regression coverage for missing tenancy and tenant mismatch deny paths

## Why
Issue #113 is about turning tenancy guarantees from documented intent into enforced behavior. The partial supervisor worktree for this issue was directionally correct, and this PR carries that forward after review.

The main change is to enforce tenancy consistency at two layers:
- executor API request handling now validates tenancy presence and equality for protected executor actions before calling the policy client
- OPA authz tests now explicitly cover the new deny reasons so the policy contract is less implicit

## Validation
- `git diff --check`
- `python3 -m py_compile executor/api_server.py executor/test_api_server_session_lifecycle.py`

## Not run on this host
- `python3 -m pytest executor/test_api_server_session_lifecycle.py executor/test_api_server_execute.py` because `pytest` is not installed here
- `bash scripts/ci/policy_eval_check.sh` because Docker daemon is not running on this host


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced tenancy validation for protected execution actions: requests with missing, blank, or mismatched tenant/scope are rejected with a 403 error.

* **Bug Fixes**
  * Return explicit 404 when a referenced session does not exist, stopping further processing.

* **Tests**
  * Added API and policy tests covering denial behavior for missing, invalid, or mismatched tenancy data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->