### PR TITLE
Bind tenant identity to authenticated callers instead of request-body self-assertion (#114)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -232,6 +232,8 @@ All tenant-facing, executor-facing, policy-facing, and chat-facing n8n webhooks 
 - Exit condition for this exception: move the shared webhook auth gate off `$env.N8N_WEBHOOK_API_KEY` to a scoped credential or deployment-injected secret, then restore `N8N_BLOCK_ENV_ACCESS_IN_NODE=true`
 - Accepted request headers at the edge: `X-API-Key: <key>` or `Authorization: Bearer <key>`
 - Accepted request headers inside the workflow auth node: `X-API-Key: <key>` or `Authorization: Bearer <key>`
+- Protected executor ingress must also receive `X-Authenticated-Tenant-Id: <tenant>` from the authenticated upstream boundary; executor tenant context is derived from that header, not trusted from request-body `tenant_id`
+- If a protected request body still includes `tenant_id`, it must exactly match `X-Authenticated-Tenant-Id` or the request is rejected with `403`
 - Failure behavior: reject before side effects with `401 Unauthorized`
 - Slack slash-command ingress keeps its separate Slack signature flow through the internal `slack-request-verifier` service, using `SLACK_SIGNING_SECRET` plus a five-minute replay window
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -202,8 +202,8 @@ Include the API key in request headers:
 curl -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-secure-api-key-here" \
+  -H "X-Authenticated-Tenant-Id: tenant-123" \
   -d '{
-    "tenant_id": "tenant-123",
     "scope": "test",
     "code": "print(\"Hello World\")"
   }'
@@ -234,7 +234,7 @@ All tenant-facing, executor-facing, policy-facing, and chat-facing n8n webhooks 
 - Accepted request headers inside the workflow auth node: `X-API-Key: <key>` or `Authorization: Bearer <key>`
 - Protected executor ingress must also receive `X-Authenticated-Tenant-Id: <tenant>` from the authenticated upstream boundary; executor tenant context is derived from that header, not trusted from request-body `tenant_id`
 - If a protected request body still includes `tenant_id`, it must exactly match `X-Authenticated-Tenant-Id` or the request is rejected with `403`
-- Failure behavior: reject before side effects with `401 Unauthorized`
+- Failure behavior: missing or invalid shared auth is rejected with `401 Unauthorized`; protected executor tenant mismatches or missing `X-Authenticated-Tenant-Id` are rejected with `403 Forbidden`
 - Slack slash-command ingress keeps its separate Slack signature flow through the internal `slack-request-verifier` service, using `SLACK_SIGNING_SECRET` plus a five-minute replay window
 
 This is intentional defense in depth. Caddy remains the first gate for `/webhook/*` with shared rate limiting, and still accepts the shared key through either `X-API-Key` or `Authorization: Bearer` for non-Slack webhooks. The `/webhook/slack-command` path is proxied through the internal `slack-request-verifier` service before n8n sees the request, so forged or replayed Slack-style requests fail with `401 Unauthorized` before any downstream workflow step runs while valid signed requests continue to the normal Slack workflow.

--- a/executor/README.md
+++ b/executor/README.md
@@ -397,8 +397,8 @@ sudo netstat -tlnp | grep 8080
 curl -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
-    "tenant_id": "t1",
     "scope": "test",
     "code": "...",
     "timeout": 120
@@ -414,8 +414,8 @@ curl -X POST http://localhost:8080/execute \
 curl -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
-    "tenant_id": "t1",
     "scope": "test",
     "code": "...",
     "template": "python-ml"

--- a/executor/README.md
+++ b/executor/README.md
@@ -53,8 +53,8 @@ curl http://localhost:8080/health
 curl -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
-    "tenant_id": "t1",
     "scope": "user:123",
     "code": "print('Hello, Sandbox!')",
     "template": "default"
@@ -138,7 +138,6 @@ Execute code in a new sandbox.
 **Request:**
 ```json
 {
-  "tenant_id": "t1",
   "scope": "user:123",
   "code": "print('Hello')",
   "language": "python",
@@ -167,10 +166,12 @@ Execute code in a new sandbox.
 
 **Request requirements:**
 - Include `X-API-Key` on executor requests.
+- Include `X-Authenticated-Tenant-Id` on protected executor requests. The executor derives tenant context from this authenticated ingress header.
 - Send `Content-Type: application/json`.
 - Request body must be a JSON object.
 - Body size is capped by `EXECUTOR_MAX_REQUEST_BODY_BYTES` and returns `413` when exceeded.
 - These same POST requirements apply to `/execute`, `/session/create`, `/session/execute`, and `/session/destroy`.
+- If a request body still includes `tenant_id`, it must exactly match `X-Authenticated-Tenant-Id` or the request is rejected with `403`.
 
 #### POST /session/create
 Create a persistent session.
@@ -180,8 +181,8 @@ Create a persistent session.
 curl -X POST http://localhost:8080/session/create \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
-    "tenant_id": "t1",
     "scope": "user:123",
     "template": "python-ml",
     "ttl": 300
@@ -191,7 +192,6 @@ curl -X POST http://localhost:8080/session/create \
 **Request:**
 ```json
 {
-  "tenant_id": "t1",
   "scope": "user:123",
   "template": "python-ml",
   "ttl": 300
@@ -216,6 +216,7 @@ Execute code in an existing session.
 curl -X POST http://localhost:8080/session/execute \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
     "session_id": "abc123def456",
     "code": "print('\''In session'\'')",
@@ -240,6 +241,7 @@ Destroy a session.
 curl -X POST http://localhost:8080/session/destroy \
   -H "Content-Type: application/json" \
   -H "X-API-Key: change-me" \
+  -H "X-Authenticated-Tenant-Id: t1" \
   -d '{
     "session_id": "abc123def456"
   }'

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -63,6 +63,15 @@ REQUEST_METRICS = {
     "statuses": {},
 }
 REQUEST_METRIC_EXCLUDE_PATHS = {"/metrics", "/metrics/prometheus", "/health"}
+AUTHENTICATED_TENANT_HEADER = "X-Authenticated-Tenant-Id"
+PROTECTED_TENANCY_ACTIONS = frozenset(
+    {
+        "executor.execute",
+        "executor.session.create",
+        "executor.session.execute",
+        "executor.session.destroy",
+    }
+)
 
 
 class RequestValidationError(ValueError):
@@ -607,6 +616,63 @@ class ExecutorHandler(BaseHTTPRequestHandler):
                 status=403,
             )
 
+    def _get_authenticated_tenant_id(self) -> Optional[str]:
+        raw_value = self.headers.get(AUTHENTICATED_TENANT_HEADER, "")
+        if not isinstance(raw_value, str):
+            return None
+        tenant_id = raw_value.strip()
+        return tenant_id or None
+
+    def _resolve_protected_tenant_id(
+        self,
+        action: str,
+        body: Dict[str, Any],
+        field: str = "tenant_id",
+    ) -> str:
+        request_tenant_id = body.get(field)
+        authenticated_tenant_id = self._get_authenticated_tenant_id()
+
+        if authenticated_tenant_id is not None:
+            if request_tenant_id is None:
+                return authenticated_tenant_id
+            if not isinstance(request_tenant_id, str) or not request_tenant_id.strip():
+                raise RequestValidationError(f"Field '{field}' must be a non-empty string")
+            if request_tenant_id.strip() != authenticated_tenant_id:
+                raise RequestValidationError(
+                    f"Invalid tenancy context for {action}: tenant_id mismatch",
+                    status=403,
+                )
+            return authenticated_tenant_id
+
+        if action in PROTECTED_TENANCY_ACTIONS and API_KEY:
+            raise RequestValidationError(
+                f"Authenticated tenant context required for {action}: missing {AUTHENTICATED_TENANT_HEADER}",
+                status=403,
+            )
+
+        return self._require_string_field(body, field)
+
+    def _bind_session_tenant_to_authenticated_caller(self, action: str, tenant_id: Any) -> str:
+        if not isinstance(tenant_id, str) or not tenant_id.strip():
+            raise RequestValidationError(
+                f"Invalid tenancy context for {action}: missing required fields subject.tenant_id, resource.tenant_id",
+                status=403,
+            )
+
+        normalized_tenant_id = tenant_id.strip()
+        authenticated_tenant_id = self._get_authenticated_tenant_id()
+        if authenticated_tenant_id is not None and authenticated_tenant_id != normalized_tenant_id:
+            raise RequestValidationError(
+                f"Invalid tenancy context for {action}: tenant_id mismatch",
+                status=403,
+            )
+        if action in PROTECTED_TENANCY_ACTIONS and API_KEY and authenticated_tenant_id is None:
+            raise RequestValidationError(
+                f"Authenticated tenant context required for {action}: missing {AUTHENTICATED_TENANT_HEADER}",
+                status=403,
+            )
+        return normalized_tenant_id
+
     def _handle_get_root(self):
         self._send_json_response({
             "status": "success",
@@ -736,8 +802,8 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_execute(self, body: Dict[str, Any]):
         """Handle direct code execution."""
-        self._require_fields_present(body, 'tenant_id', 'scope', 'code')
-        tenant_id = self._require_string_field(body, 'tenant_id')
+        self._require_fields_present(body, 'scope', 'code')
+        tenant_id = self._resolve_protected_tenant_id("executor.execute", body)
         scope = self._require_string_field(body, 'scope')
         code = self._require_string_field(body, 'code')
         language = self._optional_string_field(body, 'language', 'python')
@@ -804,8 +870,8 @@ class ExecutorHandler(BaseHTTPRequestHandler):
     
     def _handle_create_session(self, body: Dict[str, Any]):
         """Handle session creation."""
-        self._require_fields_present(body, 'tenant_id', 'scope')
-        tenant_id = self._require_string_field(body, 'tenant_id')
+        self._require_fields_present(body, 'scope')
+        tenant_id = self._resolve_protected_tenant_id("executor.session.create", body)
         scope = self._require_string_field(body, 'scope')
         template = self._optional_string_field(body, 'template', 'default')
         ttl = self._optional_int_field(body, 'ttl', 300)
@@ -862,7 +928,14 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         """Handle session destruction."""
         self._require_fields_present(body, 'session_id')
         session_id = self._require_string_field(body, 'session_id')
-        
+
+        session = session_manager.get_session(session_id)
+        if session is not None:
+            self._bind_session_tenant_to_authenticated_caller(
+                "executor.session.destroy",
+                session.metadata.get("tenant_id"),
+            )
+
         success = session_manager.destroy_session(session_id)
         
         if success:
@@ -902,7 +975,10 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             return
 
         scope = session.metadata.get("scope")
-        tenant_id = session.metadata.get("tenant_id")
+        tenant_id = self._bind_session_tenant_to_authenticated_caller(
+            "executor.session.execute",
+            session.metadata.get("tenant_id"),
+        )
         template = session.template
         policy_result = self._evaluate_policy(
             action="executor.session.execute",

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -930,7 +930,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         session_id = self._require_string_field(body, 'session_id')
         self._require_authenticated_tenant_context("executor.session.destroy")
 
-        session = session_manager.get_session(session_id)
+        session = session_manager.peek_session(session_id)
         if session is not None:
             self._bind_session_tenant_to_authenticated_caller(
                 "executor.session.destroy",
@@ -964,6 +964,22 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         files = self._optional_string_map_field(body, 'files')
         self._require_authenticated_tenant_context("executor.session.execute")
 
+        session = session_manager.peek_session(session_id)
+        if session is None:
+            self._send_json_response(
+                {
+                    "status": "error",
+                    "error": f"Session {session_id} not found or expired",
+                    "request_id": self.request_id,
+                },
+                404,
+            )
+            return
+
+        tenant_id = self._bind_session_tenant_to_authenticated_caller(
+            "executor.session.execute",
+            session.metadata.get("tenant_id"),
+        )
         session = session_manager.get_session(session_id)
         if session is None:
             self._send_json_response(
@@ -976,24 +992,18 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             )
             return
 
-        scope = session.metadata.get("scope")
-        tenant_id = self._bind_session_tenant_to_authenticated_caller(
-            "executor.session.execute",
-            session.metadata.get("tenant_id"),
-        )
-        template = session.template
         policy_result = self._evaluate_policy(
             action="executor.session.execute",
             subject={
                 "tenant_id": tenant_id,
-                "scope": scope,
+                "scope": session.metadata.get("scope"),
                 "role": "api",
             },
             resource={
                 "session_id": session_id,
                 "tenant_id": tenant_id,
-                "scope": scope,
-                "template": template,
+                "scope": session.metadata.get("scope"),
+                "template": session.template,
             },
             context={
                 "request_id": self.request_id,

--- a/executor/api_server.py
+++ b/executor/api_server.py
@@ -64,6 +64,7 @@ REQUEST_METRICS = {
 }
 REQUEST_METRIC_EXCLUDE_PATHS = {"/metrics", "/metrics/prometheus", "/health"}
 AUTHENTICATED_TENANT_HEADER = "X-Authenticated-Tenant-Id"
+CORS_ALLOWED_HEADERS = f"Content-Type, X-API-Key, X-Request-ID, {AUTHENTICATED_TENANT_HEADER}"
 PROTECTED_TENANCY_ACTIONS = frozenset(
     {
         "executor.execute",
@@ -480,7 +481,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Access-Control-Allow-Origin', origin)
         self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type, X-API-Key, X-Request-ID')
+        self.send_header('Access-Control-Allow-Headers', CORS_ALLOWED_HEADERS)
         self.send_header('Vary', 'Origin')
         self.send_header("X-Request-ID", self.request_id)
         self._send_security_headers()
@@ -623,6 +624,15 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         tenant_id = raw_value.strip()
         return tenant_id or None
 
+    def _require_authenticated_tenant_context(self, action: str) -> Optional[str]:
+        authenticated_tenant_id = self._get_authenticated_tenant_id()
+        if action in PROTECTED_TENANCY_ACTIONS and API_KEY and authenticated_tenant_id is None:
+            raise RequestValidationError(
+                f"Authenticated tenant context required for {action}: missing {AUTHENTICATED_TENANT_HEADER}",
+                status=403,
+            )
+        return authenticated_tenant_id
+
     def _resolve_protected_tenant_id(
         self,
         action: str,
@@ -630,7 +640,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         field: str = "tenant_id",
     ) -> str:
         request_tenant_id = body.get(field)
-        authenticated_tenant_id = self._get_authenticated_tenant_id()
+        authenticated_tenant_id = self._require_authenticated_tenant_context(action)
 
         if authenticated_tenant_id is not None:
             if request_tenant_id is None:
@@ -644,15 +654,11 @@ class ExecutorHandler(BaseHTTPRequestHandler):
                 )
             return authenticated_tenant_id
 
-        if action in PROTECTED_TENANCY_ACTIONS and API_KEY:
-            raise RequestValidationError(
-                f"Authenticated tenant context required for {action}: missing {AUTHENTICATED_TENANT_HEADER}",
-                status=403,
-            )
-
         return self._require_string_field(body, field)
 
     def _bind_session_tenant_to_authenticated_caller(self, action: str, tenant_id: Any) -> str:
+        authenticated_tenant_id = self._require_authenticated_tenant_context(action)
+
         if not isinstance(tenant_id, str) or not tenant_id.strip():
             raise RequestValidationError(
                 f"Invalid tenancy context for {action}: missing required fields subject.tenant_id, resource.tenant_id",
@@ -660,15 +666,9 @@ class ExecutorHandler(BaseHTTPRequestHandler):
             )
 
         normalized_tenant_id = tenant_id.strip()
-        authenticated_tenant_id = self._get_authenticated_tenant_id()
         if authenticated_tenant_id is not None and authenticated_tenant_id != normalized_tenant_id:
             raise RequestValidationError(
                 f"Invalid tenancy context for {action}: tenant_id mismatch",
-                status=403,
-            )
-        if action in PROTECTED_TENANCY_ACTIONS and API_KEY and authenticated_tenant_id is None:
-            raise RequestValidationError(
-                f"Authenticated tenant context required for {action}: missing {AUTHENTICATED_TENANT_HEADER}",
                 status=403,
             )
         return normalized_tenant_id
@@ -928,6 +928,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         """Handle session destruction."""
         self._require_fields_present(body, 'session_id')
         session_id = self._require_string_field(body, 'session_id')
+        self._require_authenticated_tenant_context("executor.session.destroy")
 
         session = session_manager.get_session(session_id)
         if session is not None:
@@ -961,6 +962,7 @@ class ExecutorHandler(BaseHTTPRequestHandler):
         code = self._require_string_field(body, 'code')
         language = self._optional_string_field(body, 'language', 'python')
         files = self._optional_string_map_field(body, 'files')
+        self._require_authenticated_tenant_context("executor.session.execute")
 
         session = session_manager.get_session(session_id)
         if session is None:

--- a/executor/session.py
+++ b/executor/session.py
@@ -297,6 +297,32 @@ class SessionManager:
                     pass
             raise
     
+    def peek_session(self, session_id: str) -> Optional[Session]:
+        """
+        Read session state without mutating TTL or usage counters.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            Session object or None if not found, inactive, or expired
+        """
+        with self._lock:
+            session = self.sessions.get(session_id)
+
+            if not session:
+                return None
+
+            if not session.is_active:
+                logger.warning(f"Session {session_id} is inactive")
+                return None
+
+            if session.is_expired:
+                logger.info(f"Session {session_id} expired during read-only lookup")
+                return None
+
+            return session
+
     def get_session(self, session_id: str) -> Optional[Session]:
         """
         Get existing session by ID.
@@ -314,14 +340,14 @@ class SessionManager:
 
         with self._lock:
             session = self.sessions.get(session_id)
-            
+
             if not session:
                 return None
-            
+
             if not session.is_active:
                 logger.warning(f"Session {session_id} is inactive")
                 return None
-            
+
             if session.is_expired:
                 logger.info(f"Session {session_id} expired, destroying")
                 _, should_delete_state = self._destroy_session_unlocked(session_id)

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -237,7 +237,7 @@ def test_execute_succeeds_with_api_key_header_when_configured():
                 server.server_port,
                 "/execute",
                 {"tenant_id": "t1", "scope": "analysis", "code": "print('ok')", "language": "python"},
-                {"X-API-Key": "secret-key"},
+                {"X-API-Key": "secret-key", "X-Authenticated-Tenant-Id": "t1"},
             )
         finally:
             server.shutdown()
@@ -249,6 +249,82 @@ def test_execute_succeeds_with_api_key_header_when_configured():
     assert payload["tenant_id"] == "t1"
     assert payload["scope"] == "analysis"
     assert payload["result"]["stdout"] == "ok"
+
+
+def test_execute_uses_authenticated_tenant_when_body_omits_tenant_id():
+    with patch.dict(os.environ, {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+        "executor.api_server.API_KEY", "secret-key"
+    ), patch(
+        "executor.api_server.template_manager.get_sandbox_kwargs", return_value={}
+    ), patch(
+        "executor.api_server.policy_client.evaluate",
+        return_value={
+            "decision": "allow",
+            "allow": True,
+            "requires_approval": False,
+            "risk_score": 0,
+            "reasons": [],
+        },
+    ), patch("executor.api_server.policy_client.enforce", return_value=True), patch(
+        "executor.api_server.CodeSandbox", _FakeSandbox
+    ):
+        server, thread = _start_server()
+        try:
+            status, payload, _headers = _post_json_raw(
+                server.server_port,
+                "/execute",
+                {"scope": "analysis", "code": "print('ok')", "language": "python"},
+                {
+                    "X-API-Key": "secret-key",
+                    "X-Authenticated-Tenant-Id": "tenant-from-auth",
+                },
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 200
+    assert payload["status"] == "success"
+    assert payload["tenant_id"] == "tenant-from-auth"
+    assert payload["scope"] == "analysis"
+
+
+def test_execute_rejects_request_body_tenant_that_conflicts_with_authenticated_tenant():
+    with patch.dict(os.environ, {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+        "executor.api_server.API_KEY", "secret-key"
+    ), patch(
+        "executor.api_server.policy_client.evaluate"
+    ) as evaluate_mock, patch("executor.api_server.policy_client.enforce") as enforce_mock, patch(
+        "executor.api_server.CodeSandbox"
+    ) as sandbox_cls:
+        server, thread = _start_server()
+        try:
+            status, payload, _headers = _post_json_raw(
+                server.server_port,
+                "/execute",
+                {
+                    "tenant_id": "tenant-from-body",
+                    "scope": "analysis",
+                    "code": "print('ok')",
+                    "language": "python",
+                },
+                {
+                    "X-API-Key": "secret-key",
+                    "X-Authenticated-Tenant-Id": "tenant-from-auth",
+                },
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 403
+    assert payload["status"] == "error"
+    assert "tenant" in payload["error"].lower()
+    evaluate_mock.assert_not_called()
+    enforce_mock.assert_not_called()
+    sandbox_cls.assert_not_called()
 
 
 def test_execute_rejects_oversized_body_before_sandbox_run():

--- a/executor/test_api_server_execute.py
+++ b/executor/test_api_server_execute.py
@@ -488,7 +488,10 @@ def test_options_echoes_request_id_header():
     assert status == 200
     assert headers["X-Request-ID"] == "opt-req-1"
     assert headers["Access-Control-Allow-Origin"] == "https://console.example.com"
-    assert headers["Access-Control-Allow-Headers"] == "Content-Type, X-API-Key, X-Request-ID"
+    assert (
+        headers["Access-Control-Allow-Headers"]
+        == "Content-Type, X-API-Key, X-Request-ID, X-Authenticated-Tenant-Id"
+    )
 
 
 def test_execute_missing_fields_returns_error():

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -258,6 +258,71 @@ def test_session_execute_denies_when_session_tenancy_metadata_is_missing():
         manager.stop()
 
 
+def test_session_execute_rejects_authenticated_tenant_mismatch_against_session():
+    manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
+    try:
+        with patch.dict("os.environ", {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+            "executor.api_server.API_KEY", "secret-key"
+        ), patch("executor.api_server.session_manager", manager), patch(
+            "executor.session.CodeSandbox", _FakeSandbox
+        ), patch(
+            "executor.api_server.policy_client.evaluate",
+            return_value={
+                "decision": "allow",
+                "allow": True,
+                "requires_approval": False,
+                "risk_score": 0,
+                "reasons": [],
+            },
+        ) as evaluate_mock, patch(
+            "executor.api_server.policy_client.enforce", return_value=True
+        ), patch(
+            "executor.api_server.session_manager.execute_in_session",
+            return_value={
+                "status": "success",
+                "exit_code": 0,
+                "stdout": "session-ok",
+                "stderr": "",
+                "language": "python",
+            },
+        ) as execute_mock:
+            session_id = manager.create_session(
+                template="default",
+                ttl=120,
+                metadata={"tenant_id": "tenant-from-session", "scope": "analysis"},
+            )
+
+            server, thread = _start_server()
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+                conn.request(
+                    "POST",
+                    "/session/execute",
+                    body=json.dumps({"session_id": session_id, "code": "print('ok')", "language": "python"}),
+                    headers={
+                        "Content-Type": "application/json",
+                        "X-API-Key": "secret-key",
+                        "X-Authenticated-Tenant-Id": "tenant-from-auth",
+                    },
+                )
+                response = conn.getresponse()
+                payload = json.loads(response.read().decode("utf-8"))
+                status = response.status
+                conn.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+        assert status == 403
+        assert payload["status"] == "error"
+        assert "tenant" in payload["error"].lower()
+        execute_mock.assert_not_called()
+        evaluate_mock.assert_not_called()
+    finally:
+        manager.stop()
+
+
 def test_session_execute_denies_when_session_tenancy_metadata_is_not_string():
     manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
     try:

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -4,7 +4,7 @@ import threading
 from http.server import HTTPServer
 from unittest.mock import patch
 
-from executor.api_server import ExecutorHandler
+from executor.api_server import AUTHENTICATED_TENANT_HEADER, ExecutorHandler
 from executor.session import SessionManager
 
 
@@ -58,9 +58,12 @@ def _start_server():
     return server, thread
 
 
-def _post_json(port: int, path: str, payload: dict):
+def _post_json(port: int, path: str, payload: dict, headers: dict | None = None):
     conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
-    conn.request("POST", path, body=json.dumps(payload), headers={"Content-Type": "application/json"})
+    request_headers = {"Content-Type": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    conn.request("POST", path, body=json.dumps(payload), headers=request_headers)
     response = conn.getresponse()
     body = response.read().decode("utf-8")
     conn.close()
@@ -321,6 +324,53 @@ def test_session_execute_rejects_authenticated_tenant_mismatch_against_session()
         evaluate_mock.assert_not_called()
     finally:
         manager.stop()
+
+
+def test_session_execute_requires_authenticated_tenant_before_session_lookup():
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.session_manager.get_session"
+    ) as get_session_mock:
+        server, thread = _start_server()
+        try:
+            status, payload = _post_json(
+                server.server_port,
+                "/session/execute",
+                {"session_id": "missing-session", "code": "print('ok')", "language": "python"},
+                {"X-API-Key": "secret-key"},
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 403
+    assert AUTHENTICATED_TENANT_HEADER.lower() in payload["error"].lower()
+    get_session_mock.assert_not_called()
+
+
+def test_session_destroy_requires_authenticated_tenant_before_session_lookup():
+    with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.session_manager.get_session"
+    ) as get_session_mock, patch(
+        "executor.api_server.session_manager.destroy_session"
+    ) as destroy_session_mock:
+        server, thread = _start_server()
+        try:
+            status, payload = _post_json(
+                server.server_port,
+                "/session/destroy",
+                {"session_id": "missing-session"},
+                {"X-API-Key": "secret-key"},
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    assert status == 403
+    assert AUTHENTICATED_TENANT_HEADER.lower() in payload["error"].lower()
+    get_session_mock.assert_not_called()
+    destroy_session_mock.assert_not_called()
 
 
 def test_session_execute_denies_when_session_tenancy_metadata_is_not_string():

--- a/executor/test_api_server_session_lifecycle.py
+++ b/executor/test_api_server_session_lifecycle.py
@@ -34,8 +34,10 @@ class _FakeStateStore:
     def __init__(self):
         self.saved = {}
         self.deleted = []
+        self.save_calls = []
 
     def save(self, session_id, payload, ttl):
+        self.save_calls.append((session_id, ttl, payload["use_count"]))
         self.saved[session_id] = {"payload": payload, "ttl": ttl}
 
     def delete(self, session_id):
@@ -262,7 +264,13 @@ def test_session_execute_denies_when_session_tenancy_metadata_is_missing():
 
 
 def test_session_execute_rejects_authenticated_tenant_mismatch_against_session():
-    manager = SessionManager(default_ttl=300, max_sessions=5, enable_cleanup_thread=False)
+    state_store = _FakeStateStore()
+    manager = SessionManager(
+        default_ttl=300,
+        max_sessions=5,
+        enable_cleanup_thread=False,
+        state_store=state_store,
+    )
     try:
         with patch.dict("os.environ", {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
             "executor.api_server.API_KEY", "secret-key"
@@ -294,6 +302,11 @@ def test_session_execute_rejects_authenticated_tenant_mismatch_against_session()
                 ttl=120,
                 metadata={"tenant_id": "tenant-from-session", "scope": "analysis"},
             )
+            session_before = manager.peek_session(session_id)
+            assert session_before is not None
+            last_used_before = session_before.last_used
+            assert len(state_store.save_calls) == 1
+            assert state_store.saved[session_id]["payload"]["use_count"] == 0
 
             server, thread = _start_server()
             try:
@@ -322,12 +335,72 @@ def test_session_execute_rejects_authenticated_tenant_mismatch_against_session()
         assert "tenant" in payload["error"].lower()
         execute_mock.assert_not_called()
         evaluate_mock.assert_not_called()
+        session_after = manager.peek_session(session_id)
+        assert session_after is not None
+        assert session_after.use_count == 0
+        assert session_after.last_used == last_used_before
+        assert len(state_store.save_calls) == 1
+        assert state_store.saved[session_id]["payload"]["use_count"] == 0
+    finally:
+        manager.stop()
+
+
+def test_session_destroy_rejects_authenticated_tenant_mismatch_without_touching_session():
+    state_store = _FakeStateStore()
+    manager = SessionManager(
+        default_ttl=300,
+        max_sessions=5,
+        enable_cleanup_thread=False,
+        state_store=state_store,
+    )
+    try:
+        with patch.dict("os.environ", {"EXECUTOR_API_KEY": "secret-key"}, clear=False), patch(
+            "executor.api_server.API_KEY", "secret-key"
+        ), patch("executor.api_server.session_manager", manager), patch(
+            "executor.session.CodeSandbox", _FakeSandbox
+        ):
+            session_id = manager.create_session(
+                template="default",
+                ttl=120,
+                metadata={"tenant_id": "tenant-from-session", "scope": "analysis"},
+            )
+            session_before = manager.peek_session(session_id)
+            assert session_before is not None
+            last_used_before = session_before.last_used
+            assert len(state_store.save_calls) == 1
+            server, thread = _start_server()
+            try:
+                status, payload = _post_json(
+                    server.server_port,
+                    "/session/destroy",
+                    {"session_id": session_id},
+                    {
+                        "X-API-Key": "secret-key",
+                        "X-Authenticated-Tenant-Id": "tenant-from-auth",
+                    },
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+        assert status == 403
+        assert payload["status"] == "error"
+        assert "tenant" in payload["error"].lower()
+        session_after = manager.peek_session(session_id)
+        assert session_after is not None
+        assert session_after.use_count == 0
+        assert session_after.last_used == last_used_before
+        assert len(state_store.save_calls) == 1
+        assert state_store.deleted == []
     finally:
         manager.stop()
 
 
 def test_session_execute_requires_authenticated_tenant_before_session_lookup():
     with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.session_manager.peek_session"
+    ) as peek_session_mock, patch(
         "executor.api_server.session_manager.get_session"
     ) as get_session_mock:
         server, thread = _start_server()
@@ -345,11 +418,14 @@ def test_session_execute_requires_authenticated_tenant_before_session_lookup():
 
     assert status == 403
     assert AUTHENTICATED_TENANT_HEADER.lower() in payload["error"].lower()
+    peek_session_mock.assert_not_called()
     get_session_mock.assert_not_called()
 
 
 def test_session_destroy_requires_authenticated_tenant_before_session_lookup():
     with patch("executor.api_server.API_KEY", "secret-key"), patch(
+        "executor.api_server.session_manager.peek_session"
+    ) as peek_session_mock, patch(
         "executor.api_server.session_manager.get_session"
     ) as get_session_mock, patch(
         "executor.api_server.session_manager.destroy_session"
@@ -369,6 +445,7 @@ def test_session_destroy_requires_authenticated_tenant_before_session_lookup():
 
     assert status == 403
     assert AUTHENTICATED_TENANT_HEADER.lower() in payload["error"].lower()
+    peek_session_mock.assert_not_called()
     get_session_mock.assert_not_called()
     destroy_session_mock.assert_not_called()
 


### PR DESCRIPTION
Closes #114
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused executor-side checkpoint for issue #114 and committed it as `82a1f58` (`Bind executor tenant to authenticated caller`).

The executor now derives tenant identity for protected routes from `X-Authenticated-Tenant-Id` instead of trusting request-body `tenant_id`, rejects body/header tenant mismatches before policy or sandbox/session side effects, and binds session execute/destroy to the authenticated tenant as well. The core changes are in [executor/api_server.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-114/executor/api_server.py), with focused coverage in [executor/test_api_server_execute.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-114/executor/test_api_server_execute.py) and [executor/test_api_server_session_lifecycle.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-114/executor/test_api_server_session_lifecycle.py). I also documented the ingress contract in [executor/README.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-114/executor/README.md) and [SECURITY.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-114/SECURITY.md).

Focused verification passed locally:
`pytest -q executor/test_api_server_execute.py executor/test_api_server_session_lifecycle.py`
I also captured the initial reproducer first: the new mismatch test failed as `200 != 403` before the fix. Broader CI scripts ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protected executor endpoints now require tenant context via X-Authenticated-Tenant-Id; tenant_id in request bodies is no longer relied upon and must match the header if present (mismatches return 403).

* **Bug Fixes**
  * CORS preflight responses now include the authenticated-tenant header.
  * Missing or mismatched tenant header now yields 403 for protected session/actions (instead of previously unified 401).

* **Documentation**
  * Examples and request requirements updated to use the header instead of tenant_id in payloads.

* **Tests**
  * Added/updated tests for header enforcement, missing header rejection, tenant-mismatch, and session lifecycle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->