### PR TITLE
Move tenant-facing SQL out of n8n workflows into dedicated services (#116)

### DIFF
--- a/.codex-supervisor/issues/116/issue-journal.md
+++ b/.codex-supervisor/issues/116/issue-journal.md
@@ -1,0 +1,48 @@
+# Issue #116: Move tenant-facing SQL out of n8n workflows into dedicated services
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/116
+- Branch: codex/issue-116
+- Workspace: .
+- Journal: .codex-supervisor/issues/116/issue-journal.md
+- Current phase: addressing_review
+- Attempt count: 2 (implementation=1, repair=1)
+- Last head SHA: b60ade095accbd845fcc5fce377af3f96c116cb3
+- Blocked reason: none
+- Last failure signature: PRRT_kwDORd-8zc56Xn6g
+- Repeated failure signature count: 1
+- Updated at: 2026-04-12T13:43:39.736Z
+
+## Latest Codex Summary
+Added a focused reproducer for the architectural boundary in commit `b60ade0` (`Add tenant workflow service boundary reproducer`). The new guard is `scripts/ci/tenant_workflow_service_boundary_check.sh`, backed by `scripts/check_tenant_workflow_service_boundary.py`, with unit coverage in [tests/test_tenant_workflow_service_boundary_check.py](tests/test_tenant_workflow_service_boundary_check.py:1).
+
+The guard reproduces the issue against the live repo by failing on direct Postgres nodes across the canonical v3 tenant-facing workflows, including `01_memory_ingest`, `02_vector_search`, `03_audit_append`, `04_executor_dispatch`, `05_policy_approval`, and the `06-12` policy-registry workflows. The focused unit test passes locally via `unittest`; host `pytest` was not installed, so I used the standard library runner instead. I also updated the local issue journal’s Codex Working Notes with the hypothesis, failure signature, and next step.
+
+Summary: Added and committed a narrow service-boundary reproducer that fails on current v3 workflows still using direct Postgres nodes.
+State hint: reproducing
+Blocked reason: none
+Tests: `python3 -m unittest -q tests.test_tenant_workflow_service_boundary_check` (passed); `bash scripts/ci/tenant_workflow_service_boundary_check.sh` (fails on current repo as intended)
+Next action: implement dedicated internal service endpoints for memory, audit, and policy-registry access, then replace the flagged v3 Postgres nodes with service-call nodes and rerun the new boundary check
+Failure signature: PRRT_kwDORd-8zc56Xn6g
+
+## Active Failure Context
+- Category: review
+- Summary: 1 unresolved automated review thread(s) remain.
+- Reference: https://github.com/TommyKammy/nexus-ai-orchestrator/pull/121#discussion_r3069535435
+- Details:
+  - scripts/ci/tenant_workflow_service_boundary_check.sh:4 summary=_⚠️ Potential issue_ | _🟡 Minor_ **Make script path resolution independent of current working directory.** Line 4 relies on being executed from repo root. url=https://github.com/TommyKammy/nexus-ai-orchestrator/pull/121#discussion_r3069535435
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The remaining blocker is still architectural, not harness-related: the shell wrapper path issue is fixed, and the boundary check now fails from any cwd only because canonical v3 tenant-facing workflows still embed direct `n8n-nodes-base.postgres` nodes.
+- What changed: Updated `scripts/ci/tenant_workflow_service_boundary_check.sh` to resolve `REPO_ROOT` from `BASH_SOURCE[0]` and pass `--repo-root` explicitly, and extended `tests/test_tenant_workflow_service_boundary_check.py` with a subprocess regression test that invokes the wrapper from outside the repo.
+- Current blocker: None. Reproduction is stable and points at workflow/service refactoring work rather than a flaky test harness.
+- Next exact step: Implement dedicated HTTP service endpoints for memory, audit, and policy-registry access, then replace the flagged Postgres nodes in `n8n/workflows-v3/01-12` with service-call nodes and rerun the new boundary check.
+- Verification gap: Full build/test gates not run yet; focused verification covered only the boundary checker unit suite and direct wrapper invocations from repo-root and a temporary external cwd.
+- Files touched: `.codex-supervisor/issues/116/issue-journal.md`, `scripts/check_tenant_workflow_service_boundary.py`, `scripts/ci/tenant_workflow_service_boundary_check.sh`, `tests/test_tenant_workflow_service_boundary_check.py`
+- Rollback concern: Low. Changes are additive and isolated to a new reproducing guard plus journal notes.
+- Last focused command: `tmpdir=$(mktemp -d) && cd "$tmpdir" && bash /Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-116/scripts/ci/tenant_workflow_service_boundary_check.sh`
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.
+- Failure signature captured: `tenant_workflow_service_boundary_postgres_nodes`
+- 2026-04-12: Addressed review thread `PRRT_kwDORd-8zc56Xn6g` locally by making the shell wrapper cwd-independent; focused verification confirmed the wrapper now executes the checker correctly from both repo-root and an external working directory.

--- a/scripts/check_tenant_workflow_service_boundary.py
+++ b/scripts/check_tenant_workflow_service_boundary.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fail when tenant-facing n8n workflows still embed direct Postgres access."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+TARGET_WORKFLOWS = (
+    "n8n/workflows-v3/01_memory_ingest.json",
+    "n8n/workflows-v3/02_vector_search.json",
+    "n8n/workflows-v3/03_audit_append.json",
+    "n8n/workflows-v3/04_executor_dispatch.json",
+    "n8n/workflows-v3/05_policy_approval.json",
+    "n8n/workflows-v3/06_policy_registry_upsert.json",
+    "n8n/workflows-v3/07_policy_registry_publish.json",
+    "n8n/workflows-v3/08_policy_registry_list.json",
+    "n8n/workflows-v3/09_policy_registry_get.json",
+    "n8n/workflows-v3/10_policy_registry_candidates.json",
+    "n8n/workflows-v3/11_policy_candidate_seed.json",
+    "n8n/workflows-v3/12_policy_registry_delete.json",
+)
+
+
+def _error(workflow_path: Path, message: str) -> str:
+    return f"{workflow_path}: {message}"
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_workflow_has_no_postgres_nodes(workflow_path: Path) -> list[str]:
+    try:
+        workflow = _load_json(workflow_path)
+    except FileNotFoundError:
+        return [_error(workflow_path, "workflow file not found")]
+    except OSError as exc:
+        return [_error(workflow_path, f"read error: {exc}")]
+    except json.JSONDecodeError as exc:
+        return [_error(workflow_path, f"invalid JSON: {exc.msg} at line {exc.lineno} col {exc.colno}")]
+
+    if not isinstance(workflow, dict):
+        return [_error(workflow_path, "top-level JSON must be an object")]
+
+    nodes = workflow.get("nodes")
+    if not isinstance(nodes, list):
+        return [_error(workflow_path, "missing/invalid 'nodes' array")]
+
+    errors: list[str] = []
+    for idx, node in enumerate(nodes):
+        if not isinstance(node, dict):
+            errors.append(_error(workflow_path, f"node[{idx}] must be an object"))
+            continue
+
+        if node.get("type") != "n8n-nodes-base.postgres":
+            continue
+
+        node_name = node.get("name") if isinstance(node.get("name"), str) else f"node[{idx}]"
+        errors.append(
+            _error(
+                workflow_path,
+                f"tenant-facing workflow must not use postgres node '{node_name}'; move data access behind a dedicated service boundary",
+            )
+        )
+
+    return errors
+
+
+def validate_repo(root: Path, workflows: tuple[str, ...] = TARGET_WORKFLOWS) -> list[str]:
+    errors: list[str] = []
+    for relative_path in workflows:
+        errors.extend(validate_workflow_has_no_postgres_nodes(root / relative_path))
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate that tenant-facing workflows orchestrate service calls instead of direct Postgres access"
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository root containing the target n8n workflows",
+    )
+    args = parser.parse_args(argv)
+
+    errors = validate_repo(Path(args.repo_root))
+    if errors:
+        print("Tenant workflow service-boundary check FAILED")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("Tenant workflow service-boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/tenant_workflow_service_boundary_check.sh
+++ b/scripts/ci/tenant_workflow_service_boundary_check.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python3 scripts/check_tenant_workflow_service_boundary.py
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
+python3 "${REPO_ROOT}/scripts/check_tenant_workflow_service_boundary.py" \
+  --repo-root "${REPO_ROOT}"

--- a/scripts/ci/tenant_workflow_service_boundary_check.sh
+++ b/scripts/ci/tenant_workflow_service_boundary_check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 scripts/check_tenant_workflow_service_boundary.py

--- a/tests/test_tenant_workflow_service_boundary_check.py
+++ b/tests/test_tenant_workflow_service_boundary_check.py
@@ -1,0 +1,110 @@
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "check_tenant_workflow_service_boundary.py"
+)
+SPEC = importlib.util.spec_from_file_location("tenant_workflow_service_boundary", MODULE_PATH)
+tenant_workflow_service_boundary = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tenant_workflow_service_boundary)
+
+
+class TenantWorkflowServiceBoundaryTests(unittest.TestCase):
+    def _make_temp_repo(self) -> Path:
+        tmpdir = Path(tempfile.mkdtemp(prefix="tenant-workflow-boundary-"))
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        (tmpdir / "n8n" / "workflows-v3").mkdir(parents=True)
+        return tmpdir
+
+    def _write_workflow(self, repo_root: Path, relative_path: str, nodes: list[dict]) -> None:
+        workflow_path = repo_root / relative_path
+        workflow_path.parent.mkdir(parents=True, exist_ok=True)
+        workflow_path.write_text(json.dumps({"name": workflow_path.stem, "nodes": nodes}, indent=2) + "\n", encoding="utf-8")
+
+    def _write_all_target_workflows(self, repo_root: Path, node_factory) -> None:
+        for relative_path in tenant_workflow_service_boundary.TARGET_WORKFLOWS:
+            self._write_workflow(repo_root, relative_path, node_factory(relative_path))
+
+    def test_validation_passes_when_target_workflows_only_orchestrate_http_calls(self):
+        repo_root = self._make_temp_repo()
+
+        self._write_all_target_workflows(
+            repo_root,
+            lambda _path: [
+                {
+                    "name": "Call Internal Service",
+                    "type": "n8n-nodes-base.httpRequest",
+                    "parameters": {"url": "http://executor:8080/internal/example"},
+                }
+            ],
+        )
+
+        errors = tenant_workflow_service_boundary.validate_repo(repo_root)
+
+        self.assertEqual(errors, [])
+
+    def test_validation_fails_when_any_target_workflow_keeps_a_postgres_node(self):
+        repo_root = self._make_temp_repo()
+
+        def node_factory(relative_path: str) -> list[dict]:
+            if relative_path.endswith("02_vector_search.json"):
+                return [
+                    {
+                        "name": "Search Vectors",
+                        "type": "n8n-nodes-base.postgres",
+                        "parameters": {"query": "SELECT * FROM memory_vectors WHERE tenant_id = $1;"},
+                    }
+                ]
+            return [
+                {
+                    "name": "Call Internal Service",
+                    "type": "n8n-nodes-base.httpRequest",
+                    "parameters": {"url": "http://executor:8080/internal/example"},
+                }
+            ]
+
+        self._write_all_target_workflows(repo_root, node_factory)
+
+        errors = tenant_workflow_service_boundary.validate_repo(repo_root)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("02_vector_search.json", errors[0])
+        self.assertIn("Search Vectors", errors[0])
+
+    def test_validation_ignores_postgres_nodes_outside_target_workflows(self):
+        repo_root = self._make_temp_repo()
+        self._write_all_target_workflows(
+            repo_root,
+            lambda _path: [
+                {
+                    "name": "Call Internal Service",
+                    "type": "n8n-nodes-base.httpRequest",
+                    "parameters": {"url": "http://executor:8080/internal/example"},
+                }
+            ],
+        )
+        self._write_workflow(
+            repo_root,
+            "n8n/workflows-v3/unrelated.json",
+            [
+                {
+                    "name": "Legacy SQL",
+                    "type": "n8n-nodes-base.postgres",
+                    "parameters": {"query": "SELECT 1;"},
+                }
+            ],
+        )
+
+        errors = tenant_workflow_service_boundary.validate_repo(repo_root)
+
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tenant_workflow_service_boundary_check.py
+++ b/tests/test_tenant_workflow_service_boundary_check.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import subprocess
 import shutil
 import tempfile
 import unittest
@@ -8,6 +9,9 @@ from pathlib import Path
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "check_tenant_workflow_service_boundary.py"
+)
+WRAPPER_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "ci" / "tenant_workflow_service_boundary_check.sh"
 )
 SPEC = importlib.util.spec_from_file_location("tenant_workflow_service_boundary", MODULE_PATH)
 tenant_workflow_service_boundary = importlib.util.module_from_spec(SPEC)
@@ -104,6 +108,22 @@ class TenantWorkflowServiceBoundaryTests(unittest.TestCase):
         errors = tenant_workflow_service_boundary.validate_repo(repo_root)
 
         self.assertEqual(errors, [])
+
+    def test_shell_wrapper_resolves_repo_root_from_another_working_directory(self):
+        outside_dir = Path(tempfile.mkdtemp(prefix="tenant-workflow-boundary-cwd-"))
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+
+        result = subprocess.run(
+            ["bash", str(WRAPPER_PATH)],
+            cwd=outside_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Tenant workflow service-boundary check FAILED", result.stdout)
+        self.assertEqual(result.stderr, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_tenant_workflow_service_boundary_check.py
+++ b/tests/test_tenant_workflow_service_boundary_check.py
@@ -110,20 +110,30 @@ class TenantWorkflowServiceBoundaryTests(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_shell_wrapper_resolves_repo_root_from_another_working_directory(self):
+        repo_root = Path(__file__).resolve().parents[1]
         outside_dir = Path(tempfile.mkdtemp(prefix="tenant-workflow-boundary-cwd-"))
         self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+        bash_path = shutil.which("bash")
+        self.assertIsNotNone(bash_path)
 
-        result = subprocess.run(
-            ["bash", str(WRAPPER_PATH)],
+        from_repo_root = subprocess.run(
+            [bash_path, str(WRAPPER_PATH)],  # noqa: S603
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        from_outside = subprocess.run(
+            [bash_path, str(WRAPPER_PATH)],  # noqa: S603
             cwd=outside_dir,
             capture_output=True,
             text=True,
             check=False,
         )
 
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("Tenant workflow service-boundary check FAILED", result.stdout)
-        self.assertEqual(result.stderr, "")
+        self.assertEqual(from_outside.returncode, from_repo_root.returncode)
+        self.assertEqual(from_outside.stdout, from_repo_root.stdout)
+        self.assertEqual(from_outside.stderr, from_repo_root.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #116
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused reproducer for the architectural boundary in commit `b60ade0` (`Add tenant workflow service boundary reproducer`). The new guard is `scripts/ci/tenant_workflow_service_boundary_check.sh`, backed by `scripts/check_tenant_workflow_service_boundary.py`, with unit coverage in [tests/test_tenant_workflow_service_boundary_check.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-116/tests/test_tenant_workflow_service_boundary_check.py:1).

The guard reproduces the issue against the live repo by failing on direct Postgres nodes across the canonical v3 tenant-facing workflows, including `01_memory_ingest`, `02_vector_search`, `03_audit_append`, `04_executor_dispatch`, `05_policy_approval`, and the `06-12` policy-registry workflows. The focused unit test passes locally via `unittest`; host `pytest` was not installed, so I used the standard library runner instead. I also updated the local issue journal’s Codex Working Notes with the hypothesis, failure signature, and next step.

Summary: Added and committed a narrow service-boundary reproducer that fails on current v3 workflows still using direct Postgres nodes.
State hint: reproducing
Blocked reason: none
Tests: `python3 -m unittest -q tests.test_tenant_workflow_service_boundary_check` (passed); `bash scripts/ci/tenant_workflow_service_boundary_check.sh` (fails on current repo as intended)
Failure signature: tenant_workflow_service_boundary_postgres_nodes
Next action: implement dedicate...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated validation script for tenant-facing workflows.
  * Added a CI wrapper to run the workflow validation check.

* **Tests**
  * Added unit and integration tests covering validation behavior and CI wrapper execution.

* **Documentation**
  * Added an issue journal entry summarizing the validation checks and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->