### PR TITLE
Enable Redis authentication/TLS and require Kubernetes ingress TLS (#117)

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -75,7 +75,8 @@ Ingress TLS before the workloads will become ready.
 Create these secrets in `executor-system` before applying the deployments:
 
 - `redis-auth`: opaque secret with key `password`
-- `redis-tls`: secret containing `ca.crt`, `tls.crt`, and `tls.key`
+- `redis-server-tls`: secret containing the Redis server `ca.crt`, `tls.crt`, and `tls.key`
+- `redis-client-tls`: secret containing the Redis client `ca.crt`, `tls.crt`, and `tls.key`
 - `executor-edge-tls`: ingress TLS certificate for `executor.local`
 
 Example:
@@ -87,11 +88,17 @@ kubectl create secret generic redis-auth \
   -n executor-system \
   --from-literal=password='replace-with-strong-password'
 
-kubectl create secret generic redis-tls \
+kubectl create secret generic redis-server-tls \
   -n executor-system \
   --from-file=ca.crt=/path/to/ca.crt \
-  --from-file=tls.crt=/path/to/redis-client-server.crt \
-  --from-file=tls.key=/path/to/redis-client-server.key
+  --from-file=tls.crt=/path/to/redis-server.crt \
+  --from-file=tls.key=/path/to/redis-server.key
+
+kubectl create secret generic redis-client-tls \
+  -n executor-system \
+  --from-file=ca.crt=/path/to/ca.crt \
+  --from-file=tls.crt=/path/to/redis-client.crt \
+  --from-file=tls.key=/path/to/redis-client.key
 
 kubectl create secret tls executor-edge-tls \
   -n executor-system \
@@ -99,9 +106,9 @@ kubectl create secret tls executor-edge-tls \
   --key=/path/to/executor-edge.key
 ```
 
-Use distinct client/server certificates if your PKI policy requires it. The bundled
-manifests mount the same `redis-tls` secret into Redis, the operator, and the load
-balancer so authenticated internal clients can complete the TLS handshake.
+Use separate client and server certificates signed by the same CA. The bundled
+manifests mount `redis-server-tls` only into Redis and `redis-client-tls` only into
+the operator and load balancer so client compromise does not expose the server key.
 
 ### 4. Build and Push Images
 
@@ -123,8 +130,9 @@ kubectl apply -f k8s/config/deployment/ingress.yaml
 ```
 
 Rollout note: `redis`, `executor-operator`, and `executor-load-balancer` will stay
-unready until `redis-auth` and `redis-tls` exist, and the ingress controller will not
-serve TLS for `executor-edge` until `executor-edge-tls` exists.
+unready until `redis-auth`, `redis-server-tls`, and `redis-client-tls` exist, and the
+ingress controller will not serve TLS for `executor-edge` until `executor-edge-tls`
+exists.
 
 ### 6. Create Executor Pools
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -67,7 +67,43 @@ If you apply the entire `k8s/config/deployment/` directory, install Prometheus O
 kubectl apply -f k8s/config/crd/executor-crd.yaml
 ```
 
-### 3. Build and Push Images
+### 3. Create Required Secrets
+
+The hardened Kubernetes path requires Redis authentication, Redis TLS/mTLS, and
+Ingress TLS before the workloads will become ready.
+
+Create these secrets in `executor-system` before applying the deployments:
+
+- `redis-auth`: opaque secret with key `password`
+- `redis-tls`: secret containing `ca.crt`, `tls.crt`, and `tls.key`
+- `executor-edge-tls`: ingress TLS certificate for `executor.local`
+
+Example:
+
+```bash
+kubectl create namespace executor-system --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic redis-auth \
+  -n executor-system \
+  --from-literal=password='replace-with-strong-password'
+
+kubectl create secret generic redis-tls \
+  -n executor-system \
+  --from-file=ca.crt=/path/to/ca.crt \
+  --from-file=tls.crt=/path/to/redis-client-server.crt \
+  --from-file=tls.key=/path/to/redis-client-server.key
+
+kubectl create secret tls executor-edge-tls \
+  -n executor-system \
+  --cert=/path/to/executor-edge.crt \
+  --key=/path/to/executor-edge.key
+```
+
+Use distinct client/server certificates if your PKI policy requires it. The bundled
+manifests mount the same `redis-tls` secret into Redis, the operator, and the load
+balancer so authenticated internal clients can complete the TLS handshake.
+
+### 4. Build and Push Images
 
 ```bash
 # Update the build script with your registry
@@ -77,7 +113,7 @@ export REGISTRY=your-registry.com/executor
 bash k8s/config/deployment/build-images.sh
 ```
 
-### 4. Deploy Operator and Infrastructure
+### 5. Deploy Operator and Infrastructure
 
 ```bash
 kubectl apply -f k8s/config/deployment/operator-deployment.yaml
@@ -86,7 +122,11 @@ kubectl apply -f k8s/config/deployment/network-policies.yaml
 kubectl apply -f k8s/config/deployment/ingress.yaml
 ```
 
-### 5. Create Executor Pools
+Rollout note: `redis`, `executor-operator`, and `executor-load-balancer` will stay
+unready until `redis-auth` and `redis-tls` exist, and the ingress controller will not
+serve TLS for `executor-edge` until `executor-edge-tls` exists.
+
+### 6. Create Executor Pools
 
 ```bash
 # Create a pool for data science workloads
@@ -114,7 +154,7 @@ spec:
 EOF
 ```
 
-### 6. Verify Deployment
+### 7. Verify Deployment
 
 ```bash
 # Check operator
@@ -132,9 +172,14 @@ kubectl get svc -n executor-system
 # Check core stack resources
 kubectl get deploy,svc,ingress -n executor-system
 
-# Verify ingress routing (example with port-forward)
-kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 18081:80
-curl -H "Host: executor.local" http://127.0.0.1:18081/health
+# Verify ingress routing over TLS (example with port-forward)
+kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 18443:443
+curl --resolve executor.local:18443:127.0.0.1 \
+  --cacert /path/to/ingress-ca.crt \
+  https://executor.local:18443/health
+
+# Verify the ingress declares a TLS secret
+kubectl get ingress executor-edge -n executor-system -o jsonpath='{.spec.tls[0].secretName}{"\n"}'
 ```
 
 ## Custom Resources
@@ -313,17 +358,41 @@ kubectl describe executorpools python-data-pool -n executor-system
 ### Redis Connection Issues
 
 ```bash
-kubectl exec -it -n executor-system deployment/redis -- redis-cli ping
+kubectl exec -it -n executor-system deployment/redis -- sh -ec '
+  redis-cli \
+    --tls \
+    --cacert /etc/redis/tls/ca.crt \
+    --cert /etc/redis/tls/tls.crt \
+    --key /etc/redis/tls/tls.key \
+    -a "$REDIS_PASSWORD" \
+    ping
+'
 ```
 
 ### Session Migration Debugging
 
 ```bash
 # Check session in Redis
-kubectl exec -it -n executor-system deployment/redis -- redis-cli hgetall executor:session:SESSION_ID
+kubectl exec -it -n executor-system deployment/redis -- sh -ec '
+  redis-cli \
+    --tls \
+    --cacert /etc/redis/tls/ca.crt \
+    --cert /etc/redis/tls/tls.crt \
+    --key /etc/redis/tls/tls.key \
+    -a "$REDIS_PASSWORD" \
+    hgetall executor:session:SESSION_ID
+'
 
 # Check session files
-kubectl exec -it -n executor-system deployment/redis -- redis-cli hkeys executor:session:SESSION_ID:files
+kubectl exec -it -n executor-system deployment/redis -- sh -ec '
+  redis-cli \
+    --tls \
+    --cacert /etc/redis/tls/ca.crt \
+    --cert /etc/redis/tls/tls.crt \
+    --key /etc/redis/tls/tls.key \
+    -a "$REDIS_PASSWORD" \
+    hkeys executor:session:SESSION_ID:files
+'
 ```
 
 ## Cleanup

--- a/k8s/config/deployment/ingress.yaml
+++ b/k8s/config/deployment/ingress.yaml
@@ -7,12 +7,17 @@ metadata:
     app.kubernetes.io/name: executor
     app.kubernetes.io/component: ingress
   annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "30"
 spec:
   # Requires an ingress controller that registers class name "nginx".
   # Override via environment-specific overlays if your class differs.
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - executor.local
+      secretName: executor-edge-tls
   rules:
     # The host must resolve in DNS or be supplied via Host header.
     - host: executor.local

--- a/k8s/config/deployment/operator-deployment.yaml
+++ b/k8s/config/deployment/operator-deployment.yaml
@@ -208,7 +208,7 @@ spec:
       volumes:
         - name: redis-client-tls
           secret:
-            secretName: redis-tls
+            secretName: redis-client-tls
 ---
 # Redis for session persistence and load balancer state
 apiVersion: apps/v1
@@ -316,7 +316,7 @@ spec:
           emptyDir: {}
         - name: redis-server-tls
           secret:
-            secretName: redis-tls
+            secretName: redis-server-tls
 ---
 apiVersion: v1
 kind: Service
@@ -423,7 +423,7 @@ spec:
       volumes:
         - name: redis-client-tls
           secret:
-            secretName: redis-tls
+            secretName: redis-client-tls
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/config/deployment/operator-deployment.yaml
+++ b/k8s/config/deployment/operator-deployment.yaml
@@ -164,7 +164,20 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: REDIS_URL
-              value: "redis://redis.executor-system.svc.cluster.local:6379"
+              value: "rediss://redis.executor-system.svc.cluster.local:6379/0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-auth
+                  key: password
+            - name: REDIS_TLS_ENABLED
+              value: "true"
+            - name: REDIS_TLS_CA_CERT_FILE
+              value: /etc/redis/tls/ca.crt
+            - name: REDIS_TLS_CERT_FILE
+              value: /etc/redis/tls/tls.crt
+            - name: REDIS_TLS_KEY_FILE
+              value: /etc/redis/tls/tls.key
           resources:
             requests:
               cpu: 100m
@@ -188,6 +201,14 @@ spec:
                 - "import kopf; print('ready')"
             initialDelaySeconds: 5
             periodSeconds: 5
+          volumeMounts:
+            - name: redis-client-tls
+              mountPath: /etc/redis/tls
+              readOnly: true
+      volumes:
+        - name: redis-client-tls
+          secret:
+            secretName: redis-tls
 ---
 # Redis for session persistence and load balancer state
 apiVersion: apps/v1
@@ -218,6 +239,26 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              exec redis-server \
+                --bind 0.0.0.0 \
+                --port 0 \
+                --tls-port 6379 \
+                --tls-cert-file /etc/redis/tls/tls.crt \
+                --tls-key-file /etc/redis/tls/tls.key \
+                --tls-ca-cert-file /etc/redis/tls/ca.crt \
+                --tls-auth-clients yes \
+                --requirepass "$REDIS_PASSWORD" \
+                --dir /data
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-auth
+                  key: password
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
@@ -234,12 +275,48 @@ spec:
             limits:
               cpu: 500m
               memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  redis-cli \
+                    --tls \
+                    --cacert /etc/redis/tls/ca.crt \
+                    --cert /etc/redis/tls/tls.crt \
+                    --key /etc/redis/tls/tls.key \
+                    -a "$REDIS_PASSWORD" \
+                    ping | grep -q PONG
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  redis-cli \
+                    --tls \
+                    --cacert /etc/redis/tls/ca.crt \
+                    --cert /etc/redis/tls/tls.crt \
+                    --key /etc/redis/tls/tls.key \
+                    -a "$REDIS_PASSWORD" \
+                    ping | grep -q PONG
+            initialDelaySeconds: 5
+            periodSeconds: 5
           volumeMounts:
             - name: redis-data
               mountPath: /data
+            - name: redis-server-tls
+              mountPath: /etc/redis/tls
+              readOnly: true
       volumes:
         - name: redis-data
           emptyDir: {}
+        - name: redis-server-tls
+          secret:
+            secretName: redis-tls
 ---
 apiVersion: v1
 kind: Service
@@ -304,7 +381,20 @@ spec:
               name: metrics
           env:
             - name: REDIS_URL
-              value: "redis://redis.executor-system.svc.cluster.local:6379"
+              value: "rediss://redis.executor-system.svc.cluster.local:6379/0"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-auth
+                  key: password
+            - name: REDIS_TLS_ENABLED
+              value: "true"
+            - name: REDIS_TLS_CA_CERT_FILE
+              value: /etc/redis/tls/ca.crt
+            - name: REDIS_TLS_CERT_FILE
+              value: /etc/redis/tls/tls.crt
+            - name: REDIS_TLS_KEY_FILE
+              value: /etc/redis/tls/tls.key
             - name: ENABLE_GEO_ROUTING
               value: "false"
           resources:
@@ -326,6 +416,14 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
+          volumeMounts:
+            - name: redis-client-tls
+              mountPath: /etc/redis/tls
+              readOnly: true
+      volumes:
+        - name: redis-client-tls
+          secret:
+            secretName: redis-tls
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/config/deployment/operator-deployment.yaml
+++ b/k8s/config/deployment/operator-deployment.yaml
@@ -198,9 +198,52 @@ spec:
               command:
                 - python
                 - -c
-                - "import kopf; print('ready')"
+                - |
+                  import asyncio
+                  import os
+
+                  import redis.asyncio as redis
+
+
+                  async def main() -> None:
+                      connection_kwargs = {
+                          "socket_connect_timeout": 3,
+                          "socket_timeout": 3,
+                      }
+
+                      redis_password = os.environ.get("REDIS_PASSWORD")
+                      if redis_password:
+                          connection_kwargs["password"] = redis_password
+
+                      if os.environ.get("REDIS_TLS_ENABLED", "").lower() == "true":
+                          connection_kwargs["ssl"] = True
+                          connection_kwargs["ssl_cert_reqs"] = os.environ.get(
+                              "REDIS_TLS_CERT_REQS", "required"
+                          )
+
+                          ca_cert = os.environ.get("REDIS_TLS_CA_CERT_FILE")
+                          cert_file = os.environ.get("REDIS_TLS_CERT_FILE")
+                          key_file = os.environ.get("REDIS_TLS_KEY_FILE")
+
+                          if ca_cert:
+                              connection_kwargs["ssl_ca_certs"] = ca_cert
+                          if cert_file:
+                              connection_kwargs["ssl_certfile"] = cert_file
+                          if key_file:
+                              connection_kwargs["ssl_keyfile"] = key_file
+
+                      client = redis.from_url(
+                          os.environ["REDIS_URL"],
+                          decode_responses=True,
+                          **connection_kwargs,
+                      )
+                      await client.ping()
+
+
+                  asyncio.run(main())
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 5
           volumeMounts:
             - name: redis-client-tls
               mountPath: /etc/redis/tls

--- a/k8s/controllers/load_balancer.py
+++ b/k8s/controllers/load_balancer.py
@@ -12,6 +12,7 @@ Distributes sessions across multiple pools/regions with:
 import asyncio
 import json
 import logging
+import os
 import random
 import time
 from dataclasses import dataclass, asdict
@@ -22,6 +23,32 @@ import redis.asyncio as redis
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _redis_connection_kwargs() -> Dict[str, str | bool]:
+    """Build optional redis-py TLS/auth kwargs from environment."""
+    connection_kwargs: Dict[str, str | bool] = {}
+
+    redis_password = os.environ.get("REDIS_PASSWORD")
+    if redis_password:
+        connection_kwargs["password"] = redis_password
+
+    if os.environ.get("REDIS_TLS_ENABLED", "").lower() == "true":
+        connection_kwargs["ssl"] = True
+        connection_kwargs["ssl_cert_reqs"] = os.environ.get("REDIS_TLS_CERT_REQS", "required")
+
+        ca_cert = os.environ.get("REDIS_TLS_CA_CERT_FILE")
+        cert_file = os.environ.get("REDIS_TLS_CERT_FILE")
+        key_file = os.environ.get("REDIS_TLS_KEY_FILE")
+
+        if ca_cert:
+            connection_kwargs["ssl_ca_certs"] = ca_cert
+        if cert_file:
+            connection_kwargs["ssl_certfile"] = cert_file
+        if key_file:
+            connection_kwargs["ssl_keyfile"] = key_file
+
+    return connection_kwargs
 
 
 class PoolStatus(Enum):
@@ -161,7 +188,11 @@ class GlobalLoadBalancer:
         """Start the load balancer."""
         logger.info("Starting Global Load Balancer")
         
-        self.redis = await redis.from_url(self.redis_url, decode_responses=True)
+        self.redis = await redis.from_url(
+            self.redis_url,
+            decode_responses=True,
+            **_redis_connection_kwargs(),
+        )
         self._running = True
         
         # Load pool configuration from Redis

--- a/k8s/controllers/load_balancer.py
+++ b/k8s/controllers/load_balancer.py
@@ -188,7 +188,7 @@ class GlobalLoadBalancer:
         """Start the load balancer."""
         logger.info("Starting Global Load Balancer")
         
-        self.redis = await redis.from_url(
+        self.redis = redis.from_url(
             self.redis_url,
             decode_responses=True,
             **_redis_connection_kwargs(),

--- a/k8s/controllers/load_balancer_server.py
+++ b/k8s/controllers/load_balancer_server.py
@@ -5,6 +5,7 @@ FastAPI-based API for the global load balancer
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 from typing import Optional
 
@@ -55,7 +56,7 @@ async def lifespan(app: FastAPI):
     """Manage application lifespan."""
     # Startup
     logger.info("Starting Load Balancer Server")
-    redis_url = "redis://redis:6379"
+    redis_url = os.environ.get("REDIS_URL", "redis://redis:6379")
     await init_load_balancer(redis_url)
     yield
     # Shutdown

--- a/k8s/controllers/operator.py
+++ b/k8s/controllers/operator.py
@@ -74,7 +74,7 @@ async def get_redis_client() -> redis.Redis:
     """Get or create Redis client."""
     global redis_client
     if redis_client is None:
-        redis_client = await redis.from_url(
+        redis_client = redis.from_url(
             REDIS_URL,
             decode_responses=True,
             **_redis_connection_kwargs(),

--- a/k8s/controllers/operator.py
+++ b/k8s/controllers/operator.py
@@ -44,11 +44,41 @@ NAMESPACE = os.environ.get("OPERATOR_NAMESPACE", "default")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://redis:6379")
 
 
+def _redis_connection_kwargs() -> Dict[str, Any]:
+    """Build optional redis-py connection kwargs from environment."""
+    connection_kwargs: Dict[str, Any] = {}
+
+    redis_password = os.environ.get("REDIS_PASSWORD")
+    if redis_password:
+        connection_kwargs["password"] = redis_password
+
+    if os.environ.get("REDIS_TLS_ENABLED", "").lower() == "true":
+        connection_kwargs["ssl"] = True
+        connection_kwargs["ssl_cert_reqs"] = os.environ.get("REDIS_TLS_CERT_REQS", "required")
+
+        ca_cert = os.environ.get("REDIS_TLS_CA_CERT_FILE")
+        cert_file = os.environ.get("REDIS_TLS_CERT_FILE")
+        key_file = os.environ.get("REDIS_TLS_KEY_FILE")
+
+        if ca_cert:
+            connection_kwargs["ssl_ca_certs"] = ca_cert
+        if cert_file:
+            connection_kwargs["ssl_certfile"] = cert_file
+        if key_file:
+            connection_kwargs["ssl_keyfile"] = key_file
+
+    return connection_kwargs
+
+
 async def get_redis_client() -> redis.Redis:
     """Get or create Redis client."""
     global redis_client
     if redis_client is None:
-        redis_client = await redis.from_url(REDIS_URL, decode_responses=True)
+        redis_client = await redis.from_url(
+            REDIS_URL,
+            decode_responses=True,
+            **_redis_connection_kwargs(),
+        )
     return redis_client
 
 

--- a/k8s/controllers/session_persistence.py
+++ b/k8s/controllers/session_persistence.py
@@ -132,7 +132,7 @@ class SessionPersistenceManager:
         """Start the persistence manager."""
         logger.info("Starting Session Persistence Manager")
         
-        self.redis = await redis.from_url(self.redis_url, decode_responses=False)
+        self.redis = redis.from_url(self.redis_url, decode_responses=False)
         self._running = True
         
         # Start periodic snapshot task

--- a/scripts/ci/lint.sh
+++ b/scripts/ci/lint.sh
@@ -12,4 +12,5 @@ bash scripts/ci/caddy_security_headers_rate_limit_check.sh
 bash scripts/ci/workflow_schema_check.sh
 python3 scripts/validate_slack_workflows.py n8n/workflows-v3
 python3 -m unittest -v tests.test_slack_ingress_security
+python3 -m unittest -v tests.test_k8s_security_posture
 python3 -m unittest -v tests.test_slack_request_verifier

--- a/scripts/ci/security_misconfig_baseline_check.sh
+++ b/scripts/ci/security_misconfig_baseline_check.sh
@@ -13,6 +13,15 @@ require_pattern() {
   fi
 }
 
+reject_pattern() {
+  local pattern="$1"
+  local file="$2"
+  if grep -Eq -- "${pattern}" "${file}"; then
+    echo "Forbidden pattern '${pattern}' present in ${file}" >&2
+    exit 1
+  fi
+}
+
 # Existing Caddy security baseline checks (headers + rate limit) must stay green.
 bash scripts/ci/caddy_security_headers_rate_limit_check.sh
 
@@ -27,7 +36,9 @@ require_pattern 'readOnlyRootFilesystem:[[:space:]]*true' k8s/config/deployment/
 require_pattern 'value:[[:space:]]*"rediss://redis\.executor-system\.svc\.cluster\.local:6379/0"' k8s/config/deployment/operator-deployment.yaml
 require_pattern 'secretKeyRef:[[:space:]]*$' k8s/config/deployment/operator-deployment.yaml
 require_pattern 'name:[[:space:]]*redis-auth' k8s/config/deployment/operator-deployment.yaml
-require_pattern 'secretName:[[:space:]]*redis-tls' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'secretName:[[:space:]]*redis-client-tls' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'secretName:[[:space:]]*redis-server-tls' k8s/config/deployment/operator-deployment.yaml
+reject_pattern 'secretName:[[:space:]]*redis-tls([[:space:]]|$)' k8s/config/deployment/operator-deployment.yaml
 require_pattern '--tls-port 6379' k8s/config/deployment/operator-deployment.yaml
 require_pattern '--port 0' k8s/config/deployment/operator-deployment.yaml
 require_pattern 'tls:' k8s/config/deployment/ingress.yaml

--- a/scripts/ci/security_misconfig_baseline_check.sh
+++ b/scripts/ci/security_misconfig_baseline_check.sh
@@ -7,7 +7,7 @@ cd "${ROOT_DIR}"
 require_pattern() {
   local pattern="$1"
   local file="$2"
-  if ! grep -Eq "${pattern}" "${file}"; then
+  if ! grep -Eq -- "${pattern}" "${file}"; then
     echo "Missing required pattern '${pattern}' in ${file}" >&2
     exit 1
   fi
@@ -24,5 +24,14 @@ require_pattern 'no-new-privileges:true' docker-compose.yml
 require_pattern 'runAsNonRoot:[[:space:]]*true' k8s/config/deployment/operator-deployment.yaml
 require_pattern 'allowPrivilegeEscalation:[[:space:]]*false' k8s/config/deployment/operator-deployment.yaml
 require_pattern 'readOnlyRootFilesystem:[[:space:]]*true' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'value:[[:space:]]*"rediss://redis\.executor-system\.svc\.cluster\.local:6379/0"' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'secretKeyRef:[[:space:]]*$' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'name:[[:space:]]*redis-auth' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'secretName:[[:space:]]*redis-tls' k8s/config/deployment/operator-deployment.yaml
+require_pattern '--tls-port 6379' k8s/config/deployment/operator-deployment.yaml
+require_pattern '--port 0' k8s/config/deployment/operator-deployment.yaml
+require_pattern 'tls:' k8s/config/deployment/ingress.yaml
+require_pattern 'secretName:[[:space:]]*executor-edge-tls' k8s/config/deployment/ingress.yaml
+require_pattern 'nginx\.ingress\.kubernetes\.io/force-ssl-redirect:[[:space:]]*"true"' k8s/config/deployment/ingress.yaml
 
 echo "misconfiguration baseline checks passed."

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -22,11 +22,11 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
 
         self.assertNotRegex(
             operator_manifest,
-            r'value:\s*"redis://redis\.executor-system\.svc\.cluster\.local(?::6379)?(?:/[^"]*)?"',
+            r"""value:\s*["']?redis://redis\.executor-system\.svc\.cluster\.local(?::6379)?(?:/[^\s"'#]*)?["']?""",
         )
         self.assertRegex(
             operator_manifest,
-            r'value:\s*"rediss://redis\.executor-system\.svc\.cluster\.local:6379/0"',
+            r"""value:\s*["']?rediss://redis\.executor-system\.svc\.cluster\.local:6379/0["']?""",
         )
         self.assertRegex(
             operator_manifest,
@@ -63,7 +63,7 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
             r"(?ms)readinessProbe:\n\s+exec:\n\s+command:\n\s+- python\n\s+- -c\n\s+- \|",
         )
         readiness_probe = re.search(
-            r"(?ms)^ {10}readinessProbe:\n(?P<block>(?:^ {12,}.*\n)+)",
+            r"(?m)^ {10}readinessProbe:\n(?P<block>(?:^(?: {12,}[^\n]*)?\n)+)",
             operator_manifest,
         )
         self.assertIsNotNone(readiness_probe)

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -1,0 +1,46 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INGRESS_MANIFEST = REPO_ROOT / "k8s" / "config" / "deployment" / "ingress.yaml"
+OPERATOR_MANIFEST = REPO_ROOT / "k8s" / "config" / "deployment" / "operator-deployment.yaml"
+
+
+class KubernetesSecurityPostureTests(unittest.TestCase):
+    def test_executor_ingress_requires_tls(self):
+        ingress_manifest = INGRESS_MANIFEST.read_text(encoding="utf-8")
+
+        self.assertRegex(
+            ingress_manifest,
+            r"(?ms)^spec:\n.*^\s*tls:\n\s*-\s*hosts:\n\s*-\s*executor\.local\n\s*secretName:\s*\S+",
+        )
+
+    def test_kubernetes_redis_path_requires_authenticated_tls(self):
+        operator_manifest = OPERATOR_MANIFEST.read_text(encoding="utf-8")
+
+        self.assertNotIn(
+            'value: "redis://redis.executor-system.svc.cluster.local:6379"',
+            operator_manifest,
+        )
+        self.assertRegex(
+            operator_manifest,
+            r'value:\s*"rediss://redis\.executor-system\.svc\.cluster\.local:6379/0"',
+        )
+        self.assertRegex(
+            operator_manifest,
+            r"secretKeyRef:\n\s+name:\s+redis-auth\n\s+key:\s+password",
+        )
+        self.assertIn("--tls-port 6379", operator_manifest)
+        self.assertIn("--port 0", operator_manifest)
+        self.assertIn("--tls-auth-clients yes", operator_manifest)
+        self.assertIn("--requirepass \"$REDIS_PASSWORD\"", operator_manifest)
+        self.assertRegex(
+            operator_manifest,
+            r"secretName:\s+redis-tls",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -20,9 +20,9 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
     def test_kubernetes_redis_path_requires_authenticated_tls(self):
         operator_manifest = OPERATOR_MANIFEST.read_text(encoding="utf-8")
 
-        self.assertNotIn(
-            'value: "redis://redis.executor-system.svc.cluster.local:6379"',
+        self.assertNotRegex(
             operator_manifest,
+            r'value:\s*"redis://redis\.executor-system\.svc\.cluster\.local(?::6379)?(?:/[^"]*)?"',
         )
         self.assertRegex(
             operator_manifest,
@@ -30,7 +30,7 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
         )
         self.assertRegex(
             operator_manifest,
-            r"secretKeyRef:\n\s+name:\s+redis-auth\n\s+key:\s+password",
+            r"(?ms)-\s+name:\s+REDIS_PASSWORD\n\s+valueFrom:\n\s+secretKeyRef:\n\s+name:\s+redis-auth\n\s+key:\s+password",
         )
         self.assertIn("--tls-port 6379", operator_manifest)
         self.assertIn("--port 0", operator_manifest)
@@ -38,7 +38,15 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
         self.assertIn("--requirepass \"$REDIS_PASSWORD\"", operator_manifest)
         self.assertRegex(
             operator_manifest,
-            r"secretName:\s+redis-tls",
+            r"secretName:\s+redis-client-tls",
+        )
+        self.assertRegex(
+            operator_manifest,
+            r"secretName:\s+redis-server-tls",
+        )
+        self.assertNotRegex(
+            operator_manifest,
+            r"secretName:\s+redis-tls\b",
         )
 
 

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -14,7 +14,7 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
 
         self.assertRegex(
             ingress_manifest,
-            r"(?ms)^spec:\n.*^\s*tls:\n\s*-\s*hosts:\n\s*-\s*executor\.local\n\s*secretName:\s*\S+",
+            r"(?ms)^spec:\n.*^\s*tls:\n\s*-\s*hosts:\n\s*-\s*executor\.local\n\s*secretName:\s*executor-edge-tls\b",
         )
 
     def test_kubernetes_redis_path_requires_authenticated_tls(self):
@@ -62,9 +62,14 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
             operator_manifest,
             r"(?ms)readinessProbe:\n\s+exec:\n\s+command:\n\s+- python\n\s+- -c\n\s+- \|",
         )
-        self.assertRegex(
+        readiness_probe = re.search(
+            r"(?ms)^ {10}readinessProbe:\n(?P<block>(?:^ {12,}.*\n)+)",
             operator_manifest,
-            r"(?ms)readinessProbe:\n.*^\s+timeoutSeconds:\s+5$",
+        )
+        self.assertIsNotNone(readiness_probe)
+        self.assertRegex(
+            readiness_probe.group("block"),
+            r"(?m)^ {12}timeoutSeconds:\s+5$",
         )
 
 

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -48,6 +48,24 @@ class KubernetesSecurityPostureTests(unittest.TestCase):
             operator_manifest,
             r"secretName:\s+redis-tls\b",
         )
+        self.assertIn('os.environ["REDIS_URL"]', operator_manifest)
+        self.assertIn('os.environ.get("REDIS_PASSWORD")', operator_manifest)
+        self.assertIn(
+            'os.environ.get("REDIS_TLS_ENABLED", "").lower() == "true"',
+            operator_manifest,
+        )
+        self.assertIn('os.environ.get("REDIS_TLS_CA_CERT_FILE")', operator_manifest)
+        self.assertIn('os.environ.get("REDIS_TLS_CERT_FILE")', operator_manifest)
+        self.assertIn('os.environ.get("REDIS_TLS_KEY_FILE")', operator_manifest)
+        self.assertIn("await client.ping()", operator_manifest)
+        self.assertRegex(
+            operator_manifest,
+            r"(?ms)readinessProbe:\n\s+exec:\n\s+command:\n\s+- python\n\s+- -c\n\s+- \|",
+        )
+        self.assertRegex(
+            operator_manifest,
+            r"(?ms)readinessProbe:\n.*^\s+timeoutSeconds:\s+5$",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #117
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the Kubernetes hardening path and checkpointed it in `569b1c5` (`Harden Kubernetes Redis and ingress TLS defaults`).

The change set does three things. It makes the K8s manifests require TLS on `executor-edge` ingress, switches the Redis path in `operator-deployment.yaml` to authenticated TLS with secret-backed password/cert material, and fixes the Python K8s Redis clients so they actually honor `REDIS_URL`, `REDIS_PASSWORD`, and TLS env vars instead of silently falling back to plain Redis. I also added a focused regression in [tests/test_k8s_security_posture.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-117/tests/test_k8s_security_posture.py) and updated [k8s/README.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-117/k8s/README.md) with the required `redis-auth`, `redis-tls`, and `executor-edge-tls` secrets plus rollout expectations.

Focused verification is green: the new K8s security regression passes, the existing ingress/slack tests still pass, and the touched Python files compile. Broader repo gates that invoke Docker are still blocked locally because this environment cannot reach a Docker daemon, so I did not claim full CI-equivalent verification.

Summary: Hardened K8s Redis to authenticated TLS, required ingress TLS, added a focused regression test, documented required secrets, and committed the checkpoint as `569b1c5`.
State hint: stabilizing
Blocked reason: verification
Tests: `pyt...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned quick-start: new secret prerequisites, renumbered steps, rollout readiness notes, HTTPS verification guidance, and updated Redis troubleshooting commands.

* **New Features**
  * Enabled HTTPS for executor ingress with forced HTTP→HTTPS redirects and moved Redis connections to authenticated TLS.

* **Chores**
  * Updated deployments to mount TLS/auth secrets and enforce Redis TLS+password checks and readiness probes.

* **Tests**
  * Added manifest-based security tests and CI lint step to validate Kubernetes/TLS/Redis posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->