### PR TITLE
Replace privileged DinD with a non-privileged execution runtime (#126)

### DIFF
--- a/.codex-supervisor/issues/126/issue-journal.md
+++ b/.codex-supervisor/issues/126/issue-journal.md
@@ -1,0 +1,40 @@
+# Issue #126: Replace privileged DinD with a non-privileged execution runtime
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/126
+- Branch: codex/issue-126
+- Workspace: .
+- Journal: .codex-supervisor/issues/126/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 9dfa3f84edf9a8f32b87c59af01a483a4da7dfbb
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-13T11:32:27.086Z
+
+## Latest Codex Summary
+- Added a focused regression asserting `docker-compose.executor.yml` does not use `privileged: true` and requires an explicit non-privileged runtime.
+- Switched the executor compose path from privileged DinD posture to `runtime: sysbox-runc`, tightened `security_opt` to `no-new-privileges:true`, and renamed the service container to `ai-executor-runtime`.
+- Updated deployment/operator docs and the production deploy script to require Sysbox and to stop referring to the old `ai-executor-dind` container name.
+- Focused verification passed with `python3 -m unittest tests.test_k8s_security_posture`.
+- Broader Docker-backed verification is currently blocked in this shell because Docker cannot reach a daemon and `docker compose` is not available as a plugin here.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: The narrowest reproducible failure is the executor compose manifest still declaring `privileged: true`; replacing that with an explicit Sysbox runtime should satisfy the issue’s core security posture change without touching the sandbox API yet.
+- What changed: Added a manifest security regression in `tests/test_k8s_security_posture.py`; updated `docker-compose.executor.yml` to use `runtime: sysbox-runc` and `no-new-privileges:true`; updated `scripts/deploy-executor-production.sh`, `executor/README.md`, and `SECURITY.md` for the Sysbox-based deployment path.
+- Current blocker: Local Docker-backed verification is blocked by environment tooling. `docker compose --env-file .env.example -f docker-compose.executor.yml config -q` fails here because this Docker installation does not expose `compose`, and `bash scripts/ci/lint.sh` fails because no Docker daemon is reachable.
+- Next exact step: Run the requested compose validation and CI scripts in an environment with Docker daemon access plus Docker Compose plugin support, then fix any runtime-specific follow-up if Sysbox config handling differs on a real host.
+- Verification gap: Have not exercised `docker compose ... config -q` successfully in this shell and have not run `bash scripts/ci/test.sh` because Docker is unavailable.
+- Files touched: docker-compose.executor.yml; tests/test_k8s_security_posture.py; scripts/deploy-executor-production.sh; executor/README.md; SECURITY.md
+- Rollback concern: Hosts without Sysbox configured will now fail deployment fast in the production script until `sysbox-runc` is installed and registered with Docker.
+- Last focused command: python3 -m unittest tests.test_k8s_security_posture
+### Scratchpad
+- Reproducer failure before fix: `AssertionError` on `privileged: true` in `tests.test_k8s_security_posture`.
+- Host-tooling failures after fix:
+  - `docker compose --env-file .env.example -f docker-compose.executor.yml config -q` -> `unknown flag: --env-file`
+  - `bash scripts/ci/lint.sh` -> `Cannot connect to the Docker daemon`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ This document describes the security features of the Executor system and provide
 ## Table of Contents
 
 1. [Security Features](#security-features)
-2. [Docker-in-Docker (DinD) Security](#docker-in-docker-dind-security)
+2. [Executor Runtime Security](#executor-runtime-security)
 3. [API Authentication](#api-authentication)
 4. [Production Deployment](#production-deployment)
 5. [Security Best Practices](#security-best-practices)
@@ -46,21 +46,22 @@ All file operations are validated through `SecurePathValidator`:
 
 ---
 
-## Docker-in-Docker (DinD) Security
+## Executor Runtime Security
 
-### Current Implementation
+### Supported Implementation
 
-The Executor currently uses **privileged Docker-in-Docker** for sandbox creation:
+The supported executor deployment uses a **Sysbox-backed Docker runtime** for sandbox creation:
 
 ```yaml
-privileged: true  # Required for Docker-in-Docker
+runtime: sysbox-runc
 ```
 
-**Security Implications:**
-- Container has full access to host devices
-- Can modify host kernel parameters
-- Bypasses most container isolation
-- Potential for container escape
+The executor service no longer depends on `privileged: true`. Docker still runs inside the executor container, but the outer service is started under the `sysbox-runc` runtime so the host does not need to grant the full privileged DinD posture.
+
+**Operational Requirements:**
+- Install Sysbox on the host
+- Configure Docker to expose the `sysbox-runc` runtime
+- Validate the compose file with `docker compose --env-file .env.example -f docker-compose.executor.yml config -q`
 
 ### Mitigations in Place
 
@@ -68,10 +69,11 @@ privileged: true  # Required for Docker-in-Docker
 2. **Localhost binding**: API only accessible via `127.0.0.1:8080`
 3. **Read-only mounts**: Executor code mounted read-only
 4. **Health checks**: Container health monitoring
+5. **No privileged outer container**: Executor service keeps `no-new-privileges:true`
 
 ### Recommended Alternatives
 
-#### Option 1: Rootless Podman (Recommended)
+#### Option 1: Rootless Podman
 
 Podman supports rootless containers and doesn't require a daemon:
 
@@ -105,9 +107,9 @@ podman system migrate
 podman run --rm hello-world
 ```
 
-#### Option 2: Sysbox Runtime
+#### Option 2: Sysbox Runtime (Current Path)
 
-Sysbox is a container runtime that enables secure DinD without privileged mode:
+Sysbox enables Docker-in-Docker style workflows without privileged mode:
 
 ```yaml
 # docker-compose.executor.yml
@@ -172,7 +174,8 @@ services:
   executor:
     image: docker:25.0-dind
     runtime: sysbox-runc  # Add this line
-    # Remove: privileged: true
+    security_opt:
+      - no-new-privileges:true
     # ... rest of config
 ```
 

--- a/docker-compose.executor.yml
+++ b/docker-compose.executor.yml
@@ -70,7 +70,7 @@ services:
     entrypoint: |
       sh -c "
         # Start Docker daemon in background inside the Sysbox runtime
-        dockerd-entrypoint.sh dockerd --host=tcp://0.0.0.0:2375 --host=unix:///var/run/docker.sock &
+        dockerd-entrypoint.sh dockerd --host=unix:///var/run/docker.sock &
         
         # Wait for Docker to be ready
         while ! docker info >/dev/null 2>&1; do

--- a/docker-compose.executor.yml
+++ b/docker-compose.executor.yml
@@ -1,8 +1,9 @@
-# docker-compose.executor.yml - Docker-in-Docker Executor Service
+# docker-compose.executor.yml - Sysbox-backed Executor Service
 # Phase 1: Core Sandbox Infrastructure
 #
-# This service provides Docker-in-Docker (DinD) capabilities for spawning
-# isolated sandbox containers per task.
+# This service provides a non-privileged Sysbox runtime for spawning
+# isolated sandbox containers per task while preserving the Docker-based
+# executor workflow.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.executor.yml up -d executor
@@ -10,14 +11,14 @@
 services:
   executor:
     image: docker:25.0-dind
-    container_name: ai-executor-dind
+    container_name: ai-executor-runtime
     restart: always
-    privileged: true  # Required for Docker-in-Docker
+    runtime: sysbox-runc
     read_only: false
     network_mode: "bridge"
     command: []
     environment:
-      # Docker daemon configuration
+      # Docker daemon configuration inside the Sysbox system container
       DOCKER_TLS_CERTDIR: ""
       DOCKER_DRIVER: overlay2
       OPA_URL: ${OPA_URL:-http://opa:8181}
@@ -34,8 +35,7 @@ services:
       # Mount logs directory
       - ./logs/executor:/logs
       
-      # Mount Docker socket from host (optional, for host Docker access)
-      # Uncomment if you want to use host Docker instead of DinD
+      # Mount Docker socket from host (optional, not recommended)
       # - /var/run/docker.sock:/var/run/docker.sock
       
       # Persistent storage for Docker data (optional)
@@ -62,14 +62,14 @@ services:
           cpus: '0.5'
           memory: 512M
     
-    # Security options (in addition to privileged: true for DinD)
+    # Keep the executor service itself non-privileged.
     security_opt:
-      - no-new-privileges:false  # Required for DinD
+      - no-new-privileges:true
     
     # Build the sandbox image on startup
     entrypoint: |
       sh -c "
-        # Start Docker daemon in background
+        # Start Docker daemon in background inside the Sysbox runtime
         dockerd-entrypoint.sh dockerd --host=tcp://0.0.0.0:2375 --host=unix:///var/run/docker.sock &
         
         # Wait for Docker to be ready

--- a/executor/README.md
+++ b/executor/README.md
@@ -335,8 +335,10 @@ template_manager.register_template(template, persist=True)
 ### Prerequisites
 - Docker 20.10+
 - Docker Compose 2.0+
-- Linux host with privileged container support
+- Linux host with the `sysbox-runc` Docker runtime installed
 - Minimum 4GB RAM, 2 CPU cores
+
+Install and configure Sysbox on the host before deploying the executor stack. The executor compose path now expects Docker to expose the `sysbox-runc` runtime and no longer relies on `privileged: true`.
 
 ### Deployment Script
 
@@ -381,9 +383,9 @@ sudo systemctl restart docker
 
 ```bash
 # Check logs
-docker logs ai-executor-dind
+docker logs ai-executor-runtime
 
-# Verify Docker socket
+# Verify executor container
 docker ps | grep executor
 
 # Check port availability

--- a/executor/README.md
+++ b/executor/README.md
@@ -39,7 +39,7 @@ export EXECUTOR_API_KEY="change-me"
 export EXECUTOR_ALLOWED_ORIGINS="https://console.example.com"
 export EXECUTOR_MAX_REQUEST_BODY_BYTES=1048576
 
-# Start with Docker-in-Docker executor
+# Start with Sysbox-backed executor
 docker compose -f docker-compose.yml -f docker-compose.executor.yml up -d executor
 
 # Wait for service to be ready

--- a/scripts/deploy-executor-production.sh
+++ b/scripts/deploy-executor-production.sh
@@ -40,6 +40,13 @@ check_prerequisites() {
         log_error "Docker Compose is not installed"
         exit 1
     fi
+
+    # Check Sysbox runtime
+    if ! docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q 'sysbox-runc'; then
+        log_error "Docker runtime 'sysbox-runc' is not available on this host"
+        log_error "Install Sysbox and configure Docker before deploying the executor"
+        exit 1
+    fi
     
     # Check if running as root or with sudo
     if [ "$EUID" -ne 0 ] && ! sudo -n true 2>/dev/null; then
@@ -112,7 +119,7 @@ health_check() {
     log_info "Running health checks..."
     
     # Check Docker container
-    if ! docker ps | grep -q "ai-executor-dind"; then
+    if ! docker ps | grep -q "ai-executor-runtime"; then
         log_error "Executor container is not running"
         exit 1
     fi
@@ -144,7 +151,7 @@ log() {
 }
 
 # Check container health
-if ! docker ps | grep -q "ai-executor-dind"; then
+if ! docker ps | grep -q "ai-executor-runtime"; then
     log "ERROR: Executor container is down"
     # Attempt restart
     cd /opt/ai-orchestrator

--- a/scripts/deploy-executor-production.sh
+++ b/scripts/deploy-executor-production.sh
@@ -41,8 +41,16 @@ check_prerequisites() {
         exit 1
     fi
 
+    # Check Docker daemon reachability before probing for Sysbox.
+    local docker_info_error
+    docker_info_error="$(docker info 2>&1 >/dev/null)" || {
+        log_error "Docker daemon is not reachable"
+        log_error "$docker_info_error"
+        exit 1
+    }
+
     # Check Sysbox runtime
-    if ! docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q 'sysbox-runc'; then
+    if ! docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q '"sysbox-runc"'; then
         log_error "Docker runtime 'sysbox-runc' is not available on this host"
         log_error "Install Sysbox and configure Docker before deploying the executor"
         exit 1

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -6,9 +6,22 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INGRESS_MANIFEST = REPO_ROOT / "k8s" / "config" / "deployment" / "ingress.yaml"
 OPERATOR_MANIFEST = REPO_ROOT / "k8s" / "config" / "deployment" / "operator-deployment.yaml"
+EXECUTOR_COMPOSE = REPO_ROOT / "docker-compose.executor.yml"
 
 
 class KubernetesSecurityPostureTests(unittest.TestCase):
+    def test_executor_compose_avoids_privileged_dind(self):
+        executor_compose = EXECUTOR_COMPOSE.read_text(encoding="utf-8")
+
+        self.assertNotRegex(
+            executor_compose,
+            r"(?m)^\s*privileged:\s*true\b",
+        )
+        self.assertRegex(
+            executor_compose,
+            r"(?m)^\s*runtime:\s*sysbox-runc\b",
+        )
+
     def test_executor_ingress_requires_tls(self):
         ingress_manifest = INGRESS_MANIFEST.read_text(encoding="utf-8")
 

--- a/tests/test_k8s_security_posture.py
+++ b/tests/test_k8s_security_posture.py
@@ -9,16 +9,47 @@ OPERATOR_MANIFEST = REPO_ROOT / "k8s" / "config" / "deployment" / "operator-depl
 EXECUTOR_COMPOSE = REPO_ROOT / "docker-compose.executor.yml"
 
 
+def extract_compose_service_block(compose_text: str, service_name: str) -> str:
+    in_services = False
+    in_target_service = False
+    block_lines = []
+
+    for line in compose_text.splitlines():
+        if not in_services:
+            if line == "services:":
+                in_services = True
+            continue
+
+        if not in_target_service:
+            if re.match(rf"^  {re.escape(service_name)}:\s*$", line):
+                in_target_service = True
+                block_lines.append(line)
+            continue
+
+        if re.match(r"^[A-Za-z0-9_-]+:\s*$", line) or re.match(
+            r"^  [A-Za-z0-9_-]+:\s*$",
+            line,
+        ):
+            break
+
+        block_lines.append(line)
+
+    return "\n".join(block_lines) + ("\n" if block_lines else "")
+
+
 class KubernetesSecurityPostureTests(unittest.TestCase):
     def test_executor_compose_avoids_privileged_dind(self):
         executor_compose = EXECUTOR_COMPOSE.read_text(encoding="utf-8")
+        executor_block = extract_compose_service_block(executor_compose, "executor")
+
+        self.assertTrue(executor_block, "executor service block should exist")
 
         self.assertNotRegex(
-            executor_compose,
+            executor_block,
             r"(?m)^\s*privileged:\s*true\b",
         )
         self.assertRegex(
-            executor_compose,
+            executor_block,
             r"(?m)^\s*runtime:\s*sysbox-runc\b",
         )
 


### PR DESCRIPTION
Closes #126
This PR was opened by codex-supervisor.
Latest Codex summary:

Replaced the executor’s privileged DinD posture with a Sysbox-backed runtime in [docker-compose.executor.yml](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-126/docker-compose.executor.yml), and added a focused regression in [tests/test_k8s_security_posture.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-126/tests/test_k8s_security_posture.py) that fails if `privileged: true` returns or if the compose file stops declaring `runtime: sysbox-runc`. I also updated the deploy path and operator docs in [scripts/deploy-executor-production.sh](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-126/scripts/deploy-executor-production.sh), [executor/README.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-126/executor/README.md), and [SECURITY.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-126/SECURITY.md) so the supported runtime is now explicitly Sysbox and the old `ai-executor-dind` name is gone. The issue journal was updated and the checkpoint is committed as `aae2fcb` with message `Replace privileged executor runtime posture`.

Focused verification passed with `python3 -m unittest tests.test_k8s_security_posture`. The requested `docker compose --env-file .env.example -f docker-compose.executor.yml config -q` could not be completed in this shell because this Docker install does not expose the `compose` plugin and treats `--...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Executor now runs under a Sysbox-backed non-privileged runtime and the executor container name was updated.

* **Documentation**
  * Updated security and executor deployment docs to reflect Sysbox runtime, install/config steps, and revised troubleshooting guidance.

* **Tests**
  * Added a regression test ensuring the executor compose config does not use privileged DinD and requires the Sysbox runtime.

* **Chores**
  * Deployment script now checks Docker reachability and Sysbox availability before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->