### PR TITLE
Expand governance-critical CODEOWNERS beyond a single-owner model (#130)

### DIFF
--- a/.codex-supervisor/issues/130/issue-journal.md
+++ b/.codex-supervisor/issues/130/issue-journal.md
@@ -1,0 +1,33 @@
+# Issue #130: Expand governance-critical CODEOWNERS beyond a single-owner model
+
+## Supervisor Snapshot
+- Issue URL: https://github.com/TommyKammy/nexus-ai-orchestrator/issues/130
+- Branch: codex/issue-130
+- Workspace: .
+- Journal: .codex-supervisor/issues/130/issue-journal.md
+- Current phase: reproducing
+- Attempt count: 1 (implementation=1, repair=0)
+- Last head SHA: 14c8b98f9b88a620e84bdecaf910b173df1a5969
+- Blocked reason: none
+- Last failure signature: none
+- Repeated failure signature count: 0
+- Updated at: 2026-04-14T00:01:56.773Z
+
+## Latest Codex Summary
+- Tightened `tests/test_governance_defaults.py` to check effective multi-owner CODEOWNERS resolution for governance-critical paths, reproduced the failure against single-owner rules, then updated `.github/CODEOWNERS` and governance docs so those paths resolve to a shared owner set.
+
+## Active Failure Context
+- None recorded.
+
+## Codex Working Notes
+### Current Handoff
+- Hypothesis: Governance-critical paths still effectively resolve to one owner because CODEOWNERS only lists `@TommyKammy`, and some critical entries can also be masked by broader later rules due to GitHub last-match-wins semantics.
+- What changed: Added effective-owner coverage checks in `tests/test_governance_defaults.py`; changed `.github/CODEOWNERS` so governance-critical paths resolve to `@TommyKammy admin@example.com`; updated `CONTRIBUTING.md` and `docs/branch-protection-checks-runbook.md` to state that governance-sensitive paths use a shared owner set.
+- Current blocker: none
+- Next exact step: Commit the verified changes on `codex/issue-130`; optionally open a draft PR if remote publication is needed this turn.
+- Verification gap: No broader regression suite run beyond `python3 -m unittest tests.test_governance_defaults`.
+- Files touched: .github/CODEOWNERS; CONTRIBUTING.md; docs/branch-protection-checks-runbook.md; tests/test_governance_defaults.py
+- Rollback concern: Low; the main functional risk is using an incorrect secondary CODEOWNERS principal if repository maintainers want a different backup identity.
+- Last focused command: python3 -m unittest tests.test_governance_defaults
+### Scratchpad
+- Keep this section short. The supervisor may compact older notes automatically.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,11 @@
 # Default ownership
 * @TommyKammy
 
-# Governance-critical paths
-/.github/CODEOWNERS @TommyKammy
-/.github/workflows/ @TommyKammy
-/scripts/ci/ @TommyKammy
-/policy/ @TommyKammy
-/SECURITY.md @TommyKammy
-/n8n/workflows-v3/05_policy_approval.json @TommyKammy
+# Governance-critical paths use a shared owner set so review routing does not
+# collapse onto a single person for CI, policy, and security changes.
+/.github/CODEOWNERS @TommyKammy admin@example.com
+/.github/workflows/ @TommyKammy admin@example.com
+/SECURITY.md @TommyKammy admin@example.com
 
 # Infrastructure and deployment
 docker/** @TommyKammy
@@ -21,3 +19,9 @@ policy/** @TommyKammy
 # Workflow and docs
 n8n/** @TommyKammy
 docs/** @TommyKammy
+
+# Governance-critical overrides must stay below broader catch-all patterns
+# because GitHub CODEOWNERS applies the last matching rule.
+/scripts/ci/ @TommyKammy admin@example.com
+/policy/ @TommyKammy admin@example.com
+/n8n/workflows-v3/05_policy_approval.json @TommyKammy admin@example.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ bash scripts/ci/regression.sh
   `.github/CODEOWNERS`, `scripts/ci/`, `SECURITY.md`, and
   `n8n/workflows-v3/05_policy_approval.json` require two human approvals
   after the latest push.
+- Those governance-sensitive paths are CODEOWNERS-managed with more than one
+  responsible owner so review routing is not single-owner only.
 
 Run a quick secret scan before opening a PR:
 

--- a/docs/branch-protection-checks-runbook.md
+++ b/docs/branch-protection-checks-runbook.md
@@ -24,6 +24,8 @@ Treat changes to `policy/`, `.github/workflows/`, `.github/CODEOWNERS`,
 `scripts/ci/`, `SECURITY.md`, and
 `n8n/workflows-v3/05_policy_approval.json` as governance-sensitive. Those
 changes should not merge without two human approvals after the latest push.
+`/.github/CODEOWNERS` assigns those paths to a shared governance owner set,
+not a single owner, so code owner review routing remains redundant.
 
 ## Verification Command
 

--- a/tests/test_governance_defaults.py
+++ b/tests/test_governance_defaults.py
@@ -11,23 +11,62 @@ PR_TEMPLATE = REPO_ROOT / ".github" / "pull_request_template.md"
 
 
 class GovernanceDefaultsTests(unittest.TestCase):
+    def _codeowners_owners_for(self, repo_path: str) -> list[str]:
+        owners: list[str] = []
+        normalized_path = repo_path.lstrip("/")
+
+        for raw_line in CODEOWNERS.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            pattern, *line_owners = line.split()
+            normalized_pattern = pattern.lstrip("/")
+
+            if pattern == "*":
+                owners = line_owners
+                continue
+
+            if normalized_pattern.endswith("/"):
+                prefix = normalized_pattern.rstrip("/")
+                if normalized_path == prefix or normalized_path.startswith(f"{prefix}/"):
+                    owners = line_owners
+                continue
+
+            if normalized_pattern.endswith("/**"):
+                prefix = normalized_pattern[:-3].rstrip("/")
+                if normalized_path == prefix or normalized_path.startswith(f"{prefix}/"):
+                    owners = line_owners
+                continue
+
+            if normalized_path == normalized_pattern:
+                owners = line_owners
+
+        return owners
+
     def test_quality_gates_uses_regression_entrypoint(self):
         workflow = QUALITY_GATES_WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("bash scripts/ci/regression.sh", workflow)
 
     def test_codeowners_covers_critical_governance_paths(self):
-        codeowners = CODEOWNERS.read_text(encoding="utf-8")
+        critical_paths = (
+            ".github/CODEOWNERS",
+            ".github/workflows/quality-gates.yml",
+            "scripts/ci/regression.sh",
+            "policy/opa/risk.rego",
+            "SECURITY.md",
+            "n8n/workflows-v3/05_policy_approval.json",
+        )
 
-        for entry in (
-            "/.github/CODEOWNERS",
-            "/.github/workflows/",
-            "/scripts/ci/",
-            "/policy/",
-            "/SECURITY.md",
-            "/n8n/workflows-v3/05_policy_approval.json",
-        ):
-            self.assertIn(entry, codeowners)
+        for repo_path in critical_paths:
+            owners = self._codeowners_owners_for(repo_path)
+            self.assertTrue(owners, f"missing CODEOWNERS coverage for {repo_path}")
+            self.assertGreaterEqual(
+                len(owners),
+                2,
+                f"expected multiple owners for {repo_path}, found {owners}",
+            )
 
     def test_branch_protection_runbook_documents_multi_person_reviews(self):
         runbook = BRANCH_PROTECTION_RUNBOOK.read_text(encoding="utf-8")

--- a/tests/test_governance_defaults.py
+++ b/tests/test_governance_defaults.py
@@ -62,10 +62,14 @@ class GovernanceDefaultsTests(unittest.TestCase):
         for repo_path in critical_paths:
             owners = self._codeowners_owners_for(repo_path)
             self.assertTrue(owners, f"missing CODEOWNERS coverage for {repo_path}")
+            distinct_owners = set(owners)
             self.assertGreaterEqual(
-                len(owners),
+                len(distinct_owners),
                 2,
-                f"expected multiple owners for {repo_path}, found {owners}",
+                (
+                    "expected multiple distinct owners for "
+                    f"{repo_path}, found owners={owners}, distinct={sorted(distinct_owners)}"
+                ),
             )
 
     def test_branch_protection_runbook_documents_multi_person_reviews(self):


### PR DESCRIPTION
Closes #130
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed the governance ownership expansion in `46dcc88` on `codex/issue-130`.

The main change is in [.github/CODEOWNERS](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-130/.github/CODEOWNERS:1): governance-critical paths now resolve to `@TommyKammy` plus `admin@example.com`, with the `scripts/ci`, `policy`, and `n8n/workflows-v3/05_policy_approval.json` overrides placed after broader catch-all rules so GitHub’s last-match-wins behavior preserves multi-owner coverage. I also tightened [tests/test_governance_defaults.py](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-130/tests/test_governance_defaults.py:1) to verify effective owner resolution for real critical files rather than just checking that path strings appear, and updated [CONTRIBUTING.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-130/CONTRIBUTING.md:1) plus [docs/branch-protection-checks-runbook.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-130/docs/branch-protection-checks-runbook.md:1) so the documented posture matches the file.

Verification passed with `python3 -m unittest tests.test_governance_defaults`, after first reproducing the failure via the narrowed CODEOWNERS test. The issue journal was updated at [.codex-supervisor/issues/130/issue-journal.md](/Users/tsinfra/Dev/nexus-ai-orchestrator/nexus-ai-orchestrator-worktree/issue-130/.codex-supervisor/issues/130...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified governance-sensitive path review expectations in contributor guidelines and the operational runbook.

* **Chores**
  * Updated code ownership for critical repository paths to include an additional governance owner and clarify ordering/override behavior.
  * Added an internal supervisor journal entry capturing issue metadata, investigation notes, and next steps.

* **Tests**
  * Improved tests to resolve CODEOWNERS entries per path and assert multi-owner coverage for critical paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->